### PR TITLE
PIPELINE-3900: Fix missing gaps after reprocessing range-detected gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "pipe-gaps"
-version = "0.9.4"
+version = "0.9.5"
 description = "Tools for detecting interruptions in vessel position reporting systems (e.g., AIS, VMS)."
 readme = "README.md"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ dependencies = [
     "importlib-resources~=6.0",
     "geopy~=2.4",
     "google-cloud-bigquery~=3.0",
-    "gfw-common[bq,beam]==0.9.0",
+    "gfw-common[bq,beam]~=0.10",
     "pandas~=2.1",
     "py-cpuinfo~=9.0",
     "pydantic~=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "pipe-gaps"
-version = "0.9.4"
+version = "0.9.5"
 description = "Tools for detecting interruptions in vessel position reporting systems (e.g., AIS, VMS)."
 readme = "README.md"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ dependencies = [
     "importlib-resources~=6.0",
     "geopy~=2.4",
     "google-cloud-bigquery~=3.0",
-    "gfw-common[bq,beam]~=0.9",
+    "gfw-common[bq,beam]~=0.10",
     "pandas~=2.1",
     "py-cpuinfo~=9.0",
     "pydantic~=2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ geographiclib==2.1
     # via geopy
 geopy==2.4.1
     # via pipe-gaps (pyproject.toml)
-gfw-common==0.9.0
+gfw-common==0.10.0
     # via pipe-gaps (pyproject.toml)
 google-api-core==2.30.0
     # via

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -313,8 +313,10 @@ class GapDetector:
             distance_m = self._gap_distance_meters(off_m, on_m)
             duration_h = self._gap_duration_seconds(off_m, on_m) * FACTOR_SECONDS_TO_HOURS
             implied_speed_knots = self._gap_implied_speed_knots(distance_m, duration_h)
+            version = on_m[self.KEY_TIMESTAMP]
         else:
             on_m = {k: None for k in off_m}
+            version = off_m[self.KEY_TIMESTAMP]
 
         gap = {}
 
@@ -333,7 +335,7 @@ class GapDetector:
         gap.update({
             self.KEY_GAP_ID: gap_id,
             self.KEY_SSVID: ssvid,
-            self.KEY_VERSION: int(datetime.now(tz=timezone.utc).timestamp()),
+            self.KEY_VERSION: int(version),
             self.KEY_DISTANCE_M: distance_m,
             self.KEY_DURATION_H: duration_h,
             self.KEY_IMPLIED_SPEED_KNOTS: implied_speed_knots,

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -96,7 +96,6 @@ class GapDetector:
     KEY_DISTANCE_M = "distance_m"
     KEY_DURATION_H = "duration_h"
     KEY_IMPLIED_SPEED_KNOTS = "implied_speed_knots"
-    KEY_DISTANCE_FROM_SHORE = "distance_from_shore_m"
     KEY_LAT = "lat"
     KEY_LON = "lon"
     KEY_SSVID = "ssvid"
@@ -366,6 +365,19 @@ class GapDetector:
         off_message[self.KEY_SSVID] = gap[self.KEY_SSVID]
 
         return off_message
+
+    def previous_positions_from_gap(self, gap: dict) -> dict:
+        """Extracts position count fields from a gap to use as base for a new gap."""
+
+        # TODO: The code is screaming for a object oriented design.
+        # TODO: Create Gap class.
+
+        return {
+            self.KEY_HOURS_BEFORE: gap[self.KEY_HOURS_BEFORE],
+            self.KEY_HOURS_BEFORE_TER: gap[self.KEY_HOURS_BEFORE_TER],
+            self.KEY_HOURS_BEFORE_SAT: gap[self.KEY_HOURS_BEFORE_SAT],
+            self.KEY_HOURS_BEFORE_DYN: gap[self.KEY_HOURS_BEFORE_DYN],
+        }
 
     # @profile  # noqa  # Uncomment to run memory profiler
     def _sort_messages(self, messages: list) -> None:

--- a/src/pipe_gaps/pipelines/detect/config.py
+++ b/src/pipe_gaps/pipelines/detect/config.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 
-from gfw.common.beam.pipeline.config import PipelineConfig
+from gfw.common.config import PipelineConfig
 from gfw.common.beam.pipeline.hooks import create_view_hook, delete_events_hook, create_table_hook
 
 from pipe_gaps.pipelines.detect.table_config import GapsTableConfig, GapsTableDescription

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -70,21 +70,7 @@ class ProcessBoundaries(DoFn):
 
         gaps = {}
 
-        # Step one.
-        # If open gap exists, close it.
-        open_gap = self._load_open_gap(side_inputs, key_value)
-        open_gap_on_m = boundaries.get_first_message_inside_range(self._date_range)
-
-        if open_gap is not None and open_gap_on_m is not None:
-            open_gap_id = open_gap[self.KEY_GAP_ID]
-            logger.debug(f"Closing existing open gap for {formatted_key}")
-            logger.debug(f"{self.KEY_GAP_ID}={open_gap_id}")
-
-            closed_gap = self._close_open_gap(open_gap, open_gap_on_m)
-            gaps[closed_gap[self.KEY_GAP_ID]] = closed_gap
-            self._debug_gap(closed_gap)
-
-        # Step two:
+        # Step one:
         # detect potential gap between last message of a group and first message of next group.
         for left, right in boundaries.consecutive_boundaries():
             messages = left.end + right.start
@@ -92,11 +78,13 @@ class ProcessBoundaries(DoFn):
             start_dt = datetime_from_timestamp(left.last_message()[self.KEY_TIMESTAMP])
 
             if not self._is_message_in_range(left.last_message()):
-                # Otherwise should be an open gap and we handle those in step one.
+                # Otherwise should be an open gap and we handle those in step two.
                 continue
 
             for g in self._gap_detector.detect(messages, start_time=start_dt):
-                gaps[g[self.KEY_GAP_ID]] = g
+                gap_id = g[self.KEY_GAP_ID]
+
+                gaps.setdefault(gap_id, []).append(g)
                 self._debug_gap(g)
 
                 # Emit open version if daily mode would have created one.
@@ -122,7 +110,23 @@ class ProcessBoundaries(DoFn):
                         base_gap=self._gap_detector.previous_positions_from_gap(g))
 
                     self._debug_gap(open_gap)
-                    gaps[f"{gap_id}_open"] = open_gap  # temporary key to avoid overwriting
+                    gaps[gap_id].append(open_gap)
+
+        # Step two.
+        # If open gap exists, close it unless it was already detected in step one.
+        open_gap = self._load_open_gap(side_inputs, key_value)
+        open_gap_on_m = boundaries.get_first_message_inside_range(self._date_range)
+
+        if open_gap is not None and open_gap_on_m is not None:
+            open_gap_id = open_gap[self.KEY_GAP_ID]
+
+            if open_gap_id not in gaps:
+                logger.debug(f"Closing existing open gap for {formatted_key}")
+                logger.debug(f"{self.KEY_GAP_ID}={open_gap_id}")
+
+                closed_gap = self._close_open_gap(open_gap, open_gap_on_m)
+                gaps[open_gap_id] = [closed_gap]
+                self._debug_gap(closed_gap)
 
         # Step three:
         # Create open gap if last message of last group met condition.
@@ -151,13 +155,15 @@ class ProcessBoundaries(DoFn):
                     off_m=last_message,
                     previous_positions=last_boundary.end[:-1]
                 )
-                gaps[new_open_gap[self.KEY_GAP_ID]] = new_open_gap
+                gaps[new_open_gap[self.KEY_GAP_ID]] = [new_open_gap]
                 self._debug_gap(new_open_gap)
 
-        logger.debug(f"Found {len(gaps)} gap(s) for boundaries {formatted_key}...")
+        total = sum(len(versions) for versions in gaps.values())
+        logger.debug(f"Found {total} gap(s) for boundaries {formatted_key}...")
 
-        for g in gaps.values():
-            yield g
+        for versions in gaps.values():
+            for g in versions:
+                yield g
 
     def _load_open_gap(self, side_inputs, key):
         side_inputs_list = self._load_side_inputs(side_inputs, key)

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -1,5 +1,4 @@
 import logging
-from math import ceil
 from typing import Iterable, Optional, Any
 from datetime import timedelta
 
@@ -104,11 +103,14 @@ class ProcessBoundaries(DoFn):
                 # This ensures range processing produces the same table state as daily processing,
                 # so that a subsequent reprocess can always reconstruct the gap from the open gap.
                 off_m = left.last_message()
+
                 off_date = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP]).date()
+                on_date = datetime_from_timestamp(g[f"end_{self.KEY_TIMESTAMP}"]).date()
+                days_spanned = (on_date - off_date).days  # excludes ON day naturally
 
                 should_emit_open = any(
                     self._gap_detector.eval_open_gap(off_m, off_date + timedelta(days=i))
-                    for i in range(ceil(g["duration_h"] / 24) - 1)  # exclude the ON day)
+                    for i in range(days_spanned)
                 )
 
                 if should_emit_open:

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -1,4 +1,5 @@
 import logging
+from math import ceil
 from typing import Iterable, Optional, Any
 from datetime import timedelta
 
@@ -98,6 +99,24 @@ class ProcessBoundaries(DoFn):
             for g in self._gap_detector.detect(messages, start_time=start_dt):
                 gaps[g[self.KEY_GAP_ID]] = g
                 self._debug_gap(g)
+
+                # Emit open version if daily mode would have created one.
+                # This ensures range processing produces the same table state as daily processing,
+                # so that a subsequent reprocess can always reconstruct the gap from the open gap.
+                off_m = left.last_message()
+                off_date = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP]).date()
+
+                should_emit_open = any(
+                    self._gap_detector.eval_open_gap(off_m, off_date + timedelta(days=i))
+                    for i in range(ceil(g["duration_h"] / 24) - 1)  # exclude the ON day)
+                )
+
+                if should_emit_open:
+                    logger.debug("Emitting open gap for recovery...")
+                    gap_id = g[self.KEY_GAP_ID]
+                    open_gap = self._gap_detector.create_gap(off_m=off_m, gap_id=gap_id)
+                    self._debug_gap(open_gap)
+                    gaps[f"{gap_id}_open"] = open_gap  # temporary key to avoid overwriting
 
         # Step three:
         # Create open gap if last message of last group met condition.

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -114,7 +114,11 @@ class ProcessBoundaries(DoFn):
                 if should_emit_open:
                     logger.debug("Emitting open gap for recovery...")
                     gap_id = g[self.KEY_GAP_ID]
-                    open_gap = self._gap_detector.create_gap(off_m=off_m, gap_id=gap_id)
+                    open_gap = self._gap_detector.create_gap(
+                        off_m=off_m,
+                        gap_id=gap_id,
+                        base_gap=self._gap_detector.previous_positions_from_gap(g))
+
                     self._debug_gap(open_gap)
                     gaps[f"{gap_id}_open"] = open_gap  # temporary key to avoid overwriting
 

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -1,4 +1,5 @@
 import logging
+from math import ceil
 from typing import Iterable, Any
 from datetime import timedelta, date
 
@@ -70,6 +71,24 @@ class ProcessGroup(DoFn):
 
         for gap in gaps:
             self._debug_gap(gap)
+
+            # Emit open version if daily mode would have created one on any day between OFF and ON.
+            # This ensures range processing produces the same table state as daily processing,
+            # so that a subsequent reprocess can always reconstruct the gap from the open version.
+            off_m = self._gd.off_message_from_gap(gap)
+            off_date = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP]).date()
+
+            should_emit_open = any(
+                self._gd.eval_open_gap(off_m, off_date + timedelta(days=i))
+                for i in range(ceil(gap["duration_h"] / 24) - 1)  # exclude the ON day
+            )
+
+            if should_emit_open:
+                logger.debug("Emitting open gap for recovery...")
+                open_gap = self._gd.create_gap(off_m=off_m, gap_id=gap[self.KEY_GAP_ID])
+                self._debug_gap(open_gap)
+                yield open_gap
+
             yield gap
 
     def _get_index_for_time(self, messages: list, time):

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -48,13 +48,13 @@ class ProcessGroup(DoFn):
         if self._date_range is not None:
             range_start_time = datetime_from_date(self._date_range[0])
 
-            start_index = self._get_index_for_time(messages, range_start_time)
-            if start_index > 0:
+            start_idx = self._get_index_for_time(messages, range_start_time)
+            if start_idx > 0:
                 # To also evaluate first message with previous one
-                start_index = start_index - 1
+                start_idx = start_idx - 1
 
-            range_start_time = datetime_from_timestamp(messages[start_index][self.KEY_TIMESTAMP])
-            start_time = max(start_time, range_start_time)
+            effective_start_time = datetime_from_timestamp(messages[start_idx][self.KEY_TIMESTAMP])
+            start_time = max(start_time, effective_start_time)
 
         gaps = self._gd.detect(messages=messages, start_time=start_time)
 
@@ -75,8 +75,9 @@ class ProcessGroup(DoFn):
             # This ensures range processing produces the same table state as daily processing,
             # so that a subsequent reprocess can always reconstruct the gap from the open version.
             off_m = self._gd.off_message_from_gap(gap)
+            off_m_ts = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP])
 
-            off_date = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP]).date()
+            off_date = off_m_ts.date()
             on_date = datetime_from_timestamp(gap[f"end_{self.KEY_TIMESTAMP}"]).date()
             days_spanned = (on_date - off_date).days  # excludes ON day naturally
 
@@ -85,7 +86,10 @@ class ProcessGroup(DoFn):
                 for i in range(days_spanned)
             )
 
-            if should_emit_open:
+            # Don't emit open v1 if OFF is before range start - it's handled via side inputs.
+            is_before_range = self._date_range is not None and off_m_ts < range_start_time
+
+            if should_emit_open and not is_before_range:
                 logger.debug("Emitting open gap for recovery...")
                 open_gap = self._gd.create_gap(
                     off_m=off_m,

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -85,7 +85,11 @@ class ProcessGroup(DoFn):
 
             if should_emit_open:
                 logger.debug("Emitting open gap for recovery...")
-                open_gap = self._gd.create_gap(off_m=off_m, gap_id=gap[self.KEY_GAP_ID])
+                open_gap = self._gd.create_gap(
+                    off_m=off_m,
+                    gap_id=gap[self.KEY_GAP_ID],
+                    base_gap=self._gd.previous_positions_from_gap(gap))
+
                 self._debug_gap(open_gap)
                 yield open_gap
 

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -1,5 +1,4 @@
 import logging
-from math import ceil
 from typing import Iterable, Any
 from datetime import timedelta, date
 
@@ -76,11 +75,14 @@ class ProcessGroup(DoFn):
             # This ensures range processing produces the same table state as daily processing,
             # so that a subsequent reprocess can always reconstruct the gap from the open version.
             off_m = self._gd.off_message_from_gap(gap)
+
             off_date = datetime_from_timestamp(off_m[self.KEY_TIMESTAMP]).date()
+            on_date = datetime_from_timestamp(gap[f"end_{self.KEY_TIMESTAMP}"]).date()
+            days_spanned = (on_date - off_date).days  # excludes ON day naturally
 
             should_emit_open = any(
                 self._gd.eval_open_gap(off_m, off_date + timedelta(days=i))
-                for i in range(ceil(gap["duration_h"] / 24) - 1)  # exclude the ON day
+                for i in range(days_spanned)
             )
 
             if should_emit_open:

--- a/src/pipe_gaps/pipelines/detect/hooks.py
+++ b/src/pipe_gaps/pipelines/detect/hooks.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 from google.cloud import bigquery
 
-from gfw.common.beam.pipeline.config import PipelineConfig
+from gfw.common.config import PipelineConfig
 from gfw.common.beam.pipeline.base import Pipeline
 from gfw.common.bigquery.helper import BigQueryHelper
 

--- a/src/pipe_gaps/pipelines/publish/config.py
+++ b/src/pipe_gaps/pipelines/publish/config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 
 # This command does not use beam but PipelineConfig has generic functionality.
 # TODO: move PipelineConfig to a more generic package inside gfw-common lib.
-from gfw.common.beam.pipeline.config import PipelineConfig
+from gfw.common.config import PipelineConfig
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ from typing import Optional
 from datetime import datetime, timezone
 
 from gfw.common.logging import LoggerConfig
+from gfw.common.io import json_save
 
 from pipe_gaps.core import GapDetector
-from gfw.common.io import json_save
-from pipe_gaps.assets import get_sample_messages
+from pipe_gaps.assets import schemas, get_sample_messages
 
 
 LoggerConfig(
@@ -34,6 +34,21 @@ def utc_datetime(*args):
     return datetime(*args, tzinfo=timezone.utc)
 
 
+OUTPUT_GAPS_KEY_NOT_IN_SCHEMA = "Output gaps query contains key '{}' not present in output schema."
+SCHEMA_KEY_NOT_IN_OUTPUT_GAP = "Output schema contains key '{}' not present in output gaps."
+
+
+def assert_gap_complies_schema(gap: dict):
+    """Asserts that a gap dict matches the expected schema keys exactly."""
+    schema = schemas.get_schema("gaps.json")
+
+    schema_keys = [f["name"] for f in schema]
+    for k in gap:
+        assert k in schema_keys, OUTPUT_GAPS_KEY_NOT_IN_SCHEMA.format(k)
+    for k in schema_keys:
+        assert k in gap, SCHEMA_KEY_NOT_IN_OUTPUT_GAP.format(k)
+
+
 def create_message(
     time: datetime,
     ssvid: str = "446013750",
@@ -43,6 +58,8 @@ def create_message(
     lon: Optional[float] = None,
     ais_class: str = "A",
     receiver_type: str = "terrestrial",
+    distance_from_shore_m: int = 50,
+    distance_from_port_m: int = 50,
     **kwargs
 ):
     return {
@@ -54,6 +71,8 @@ def create_message(
         "lat": lat,
         "lon": lon,
         "ais_class": ais_class,
+        "distance_from_shore_m": distance_from_shore_m,
+        "distance_from_port_m": distance_from_port_m,
         **kwargs
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -626,5 +626,53 @@ class TestCases:
                 (utc_datetime(2020, 12, 27, 0, 6, 1), None),
             ],
             "id": "recreate_gap_after_reprocess__boundaries_subday_gap"
+        },
+        {
+            "messages": {
+                "2020-12-27": [
+                    create_message(time=datetime(2020, 12, 27, 0, 31)),
+                ],
+                "2020-12-28": [
+                    create_message(time=datetime(2020, 12, 28, 0, 4)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 1,
+            "window_period_d": 2,
+            "date_ranges": [
+                ("2020-12-27", "2020-12-31"),
+                ("2020-12-28", "2021-01-01"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2020, 12, 27, 0, 31), None),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
+                (utc_datetime(2020, 12, 28, 0, 4), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_correct_end_timestamp"
+        },
+        {
+            "messages": {
+                "2020-12-27": [
+                    create_message(time=datetime(2020, 12, 27, 0, 31)),
+                ],
+                "2020-12-28": [
+                    create_message(time=datetime(2020, 12, 28, 0, 4)),
+                    create_message(time=datetime(2020, 12, 28, 10, 0)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 1,
+            "window_period_d": 2,
+            "date_ranges": [
+                ("2020-12-27", "2020-12-31"),
+                ("2020-12-28", "2021-01-01"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2020, 12, 27, 0, 31), None),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
+                (utc_datetime(2020, 12, 28, 0, 4), utc_datetime(2020, 12, 28, 10, 0)),
+                (utc_datetime(2020, 12, 28, 10, 0), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_on_in_interior"
         }
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,7 +324,7 @@ class TestCases:
             "messages": [
                 create_message(time=datetime(2024, 2, 1, 4)),
                 create_message(time=datetime(2024, 2, 1, 10)),
-                create_message(time=datetime(2024, 2, 1, 15)),  # gap 1
+                create_message(time=datetime(2024, 2, 1, 15)),  # gap 1 + open gap
                 create_message(time=datetime(2024, 2, 2, 5)),
                 create_message(time=datetime(2024, 2, 2, 11)),  # gap 2
                 create_message(time=datetime(2024, 2, 2, 20)),
@@ -336,7 +336,7 @@ class TestCases:
             "threshold": 6,
             "date_range": ("2024-02-01", "2024-02-04"),
             "window_period_d": 1,
-            "expected_gaps": 3,
+            "expected_gaps": 4,
             "eval_last": True,
             "id": "period_1_day_for_3_days"
         },
@@ -446,6 +446,13 @@ class TestCases:
                     "positions_hours_before": 4,
                     "positions_hours_before_ter": 2,
                     "positions_hours_before_sat": 1,
+                    "positions_hours_before_dyn": 1
+                },
+                # open v1 for gap 2 - same counts as gap 2
+                {
+                    "positions_hours_before": 5,
+                    "positions_hours_before_ter": 2,
+                    "positions_hours_before_sat": 2,
                     "positions_hours_before_dyn": 1
                 },
                 {
@@ -595,5 +602,29 @@ class TestCases:
                 (utc_datetime(2024, 1, 6, 10), None),
             ],
             "id": "recreate_gap_after_reprocess__group_off_close_to_midnight"
+        },
+        {
+            "messages": {
+                "2020-12-26": [
+                    create_message(time=datetime(2020, 12, 26, 17, 31, 37)),
+                ],
+                "2020-12-27": [
+                    create_message(time=datetime(2020, 12, 27, 0, 6, 1)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 1,
+            "window_period_d": 2,
+            "date_ranges": [
+                ("2020-12-26", "2020-12-30"),
+                ("2020-12-27", "2020-12-31"),
+                ("2020-12-28", "2021-01-01"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2020, 12, 26, 17, 31, 37), None),
+                (utc_datetime(2020, 12, 26, 17, 31, 37), utc_datetime(2020, 12, 27, 0, 6, 1)),
+                (utc_datetime(2020, 12, 27, 0, 6, 1), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_subday_gap"
         }
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,8 @@ class TestCases:
                 create_message(ssvid="226013750", time=datetime(2024, 1, 1, 1)),
             ],
             "threshold": 1,
-            "expected_gaps": 2,
-            "id": "same_ssvid_two_gaps"
+            "expected_gaps": 4,
+            "id": "same_ssvid_two_closed_gaps_two_open_gaps"
         },
         {
             "messages": [
@@ -289,15 +289,15 @@ class TestCases:
             "messages": [
                 create_message(time=datetime(2024, 1, 31, 8)),   # This shouldn´t be detected.
                 create_message(time=datetime(2024, 1, 31, 16)),  # gap 1
-                create_message(time=datetime(2024, 2, 1, 20)),   # gap 2.
-                create_message(time=datetime(2024, 2, 10, 1)),   # gap 3.
+                create_message(time=datetime(2024, 2, 1, 20)),   # gap 2 + open gap.
+                create_message(time=datetime(2024, 2, 10, 1)),   # gap 3 + open gap.
                 create_message(time=datetime(2024, 2, 28, 23)),  # gap 4 (2024 is leap year).
             ],
             "open_gaps": [],
             "threshold": 10,
             "date_range": ("2024-02-01", "2024-03-01"),  # We want to process february.
             "window_period_d": 1,
-            "expected_gaps": 4,
+            "expected_gaps": 6,
             "eval_last": True,
             "id": "period_1_day"
         },
@@ -375,7 +375,7 @@ class TestCases:
             "date_range": ("2024-02-01", "2024-03-01"),  # We want to process february.
             "window_period_d": 30,
             "eval_last": True,
-            "expected_gaps": 4,
+            "expected_gaps": 6,
             "id": "period_30_days"
         },
         {
@@ -468,6 +468,7 @@ class TestCases:
                 ]
             },
             "open_gaps": [],
+            "window_period_d": 1,
             "threshold": 6,
             "date_ranges": [
                 ("2024-01-01", "2024-01-02"),
@@ -483,4 +484,97 @@ class TestCases:
             ],
             "id": "gap_after_6_pm_with_end_after_tomorrow"
         },
+        {
+            "messages": {
+                "2024-01-01": [
+                    create_message(time=datetime(2024, 1, 1, 1)),  # gap OFF
+                ],
+                "2024-01-03": [
+                    create_message(time=datetime(2024, 1, 3, 20)),  # gap ON
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 6,
+            "window_period_d": 4,
+            "date_ranges": [
+                ("2024-01-01", "2024-01-05"),
+                ("2024-01-02", "2024-01-06"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2024, 1, 1, 1), None),
+                (utc_datetime(2024, 1, 1, 1), utc_datetime(2024, 1, 3, 20)),
+                (utc_datetime(2024, 1, 3, 20), None),
+
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_off_far_from_midnight"
+        },
+        {
+            "messages": {
+                "2024-01-02": [
+                    create_message(time=datetime(2024, 1, 2, 22)),
+                ],
+                "2024-01-05": [
+                    create_message(time=datetime(2024, 1, 5, 10)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 6,
+            "window_period_d": 4,
+            "date_ranges": [
+                ("2024-01-01", "2024-01-05"),
+                ("2024-01-04", "2024-01-08"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2024, 1, 2, 22), None),
+                (utc_datetime(2024, 1, 2, 22), utc_datetime(2024, 1, 5, 10)),
+                (utc_datetime(2024, 1, 5, 10), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_off_close_to_midnight"
+        },
+        {
+            "messages": {
+                "2024-01-03": [
+                    create_message(time=datetime(2024, 1, 3, 1)),
+                ],
+                "2024-01-06": [
+                    create_message(time=datetime(2024, 1, 6, 23)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 6,
+            "window_period_d": 4,
+            "date_ranges": [
+                ("2024-01-03", "2024-01-07"),
+                ("2024-01-05", "2024-01-09"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2024, 1, 3, 1), None),
+                (utc_datetime(2024, 1, 3, 1), utc_datetime(2024, 1, 6, 23)),
+                (utc_datetime(2024, 1, 6, 23), None),
+            ],
+            "id": "recreate_gap_after_reprocess__group_off_far_from_midnight"
+        },
+        {
+            "messages": {
+                "2024-01-03": [
+                    create_message(time=datetime(2024, 1, 3, 22)),
+                ],
+                "2024-01-06": [
+                    create_message(time=datetime(2024, 1, 6, 10)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 6,
+            "window_period_d": 4,
+            "date_ranges": [
+                ("2024-01-03", "2024-01-07"),
+                ("2024-01-05", "2024-01-09"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2024, 1, 3, 22), None),
+                (utc_datetime(2024, 1, 3, 22), utc_datetime(2024, 1, 6, 10)),
+                (utc_datetime(2024, 1, 6, 10), None),
+            ],
+            "id": "recreate_gap_after_reprocess__group_off_close_to_midnight"
+        }
     ]

--- a/tests/pipelines/detect/test_schemas.py
+++ b/tests/pipelines/detect/test_schemas.py
@@ -6,9 +6,7 @@ from pipe_gaps.core import GapDetector
 from pipe_gaps.assets import schemas
 from pipe_gaps.queries import Gap
 
-
-OUTPUT_GAPS_KEY_NOT_IN_SCHEMA = "Output gaps query contains key '{}' not present in output schema."
-SCHEMA_KEY_NOT_IN_OUTPUT_GAP = "Output schema contains key '{}' not present in output gaps."
+from tests.conftest import assert_gap_complies_schema
 
 GAPS_QUERY_KEY_NOT_IN_SCHEMA = "Gaps query contains key '{}' not present in output schema."
 SCHEMA_KEY_NOT_IN_GAPS_QUERY = "Output schema contains key '{}' not present in Gaps query."
@@ -16,18 +14,9 @@ SCHEMA_KEY_NOT_IN_GAPS_QUERY = "Output schema contains key '{}' not present in G
 
 def test_output_gaps_comply_schema(input_file):
     messages = json_load(input_file)
-    schema = schemas.get_schema("gaps.json")
-
     detector = GapDetector(threshold=1.2, normalize_output=True)
     gap = detector.create_gap(messages[20], messages[21], previous_positions=messages[0:20])
-
-    schema_keys = [f["name"] for f in schema]
-
-    for k in gap:
-        assert k in schema_keys, OUTPUT_GAPS_KEY_NOT_IN_SCHEMA.format(k)
-
-    for k in schema_keys:
-        assert k in gap, SCHEMA_KEY_NOT_IN_OUTPUT_GAP.format(k)
+    assert_gap_complies_schema(gap)
 
 
 def test_input_gaps_comply_schema(input_file):

--- a/tests/pipelines/detect/transforms/test_detect_gaps.py
+++ b/tests/pipelines/detect/transforms/test_detect_gaps.py
@@ -13,7 +13,7 @@ from gfw.common.io import json_load
 from pipe_gaps.core import GapDetector
 from pipe_gaps.pipelines.detect.transforms.detect_gaps import DetectGaps
 
-from tests.conftest import TestCases
+from tests.conftest import TestCases, assert_gap_complies_schema
 
 
 logger = logging.getLogger(__name__)
@@ -417,3 +417,5 @@ def test_incremental_mode(
         gap_end_dt = datetime_from_timestamp(gap_end_ts) if gap_end_ts is not None else None
         assert gap_start_dt == expected_gap[0]
         assert gap_end_dt == expected_gap[1]
+
+        assert_gap_complies_schema(gap)

--- a/tests/pipelines/detect/transforms/test_detect_gaps.py
+++ b/tests/pipelines/detect/transforms/test_detect_gaps.py
@@ -41,7 +41,7 @@ POSITIONS_HOURS_BEFORE_KEYS = [
 )
 def test_detect_gaps_between_years(messages, threshold, expected_gaps):
     # Setup
-    gap_detector = GapDetector(threshold=threshold)
+    gap_detector = GapDetector(threshold=threshold, normalize_output=True)
 
     # Run test pipeline
     with _TestPipeline() as p:
@@ -81,7 +81,7 @@ def test_detect_gaps_between_years(messages, threshold, expected_gaps):
 def test_detect_gaps_between_days(messages, open_gaps, threshold, date_range, expected_gaps):
     """Checks that DetectGaps correctly detects gaps between days including use of side inputs."""
 
-    gap_detector = GapDetector(threshold=threshold)
+    gap_detector = GapDetector(threshold=threshold, normalize_output=True)
 
     with _TestPipeline() as p:
         main_input = p | "CreateMessages" >> beam.Create(messages)
@@ -101,7 +101,7 @@ def test_detect_gaps_between_days(messages, open_gaps, threshold, date_range, ex
         def check_output(gaps):
             assert len(gaps) == len(expected_gaps)
 
-            gaps = sorted(gaps, key=lambda x: x["OFF"]["timestamp"])
+            gaps = sorted(gaps, key=lambda x: x["start_timestamp"])
             for gap, expected_gap in zip(gaps, expected_gaps):
                 for k in POSITIONS_HOURS_BEFORE_KEYS:
                     assert gap[k] == expected_gap[k]
@@ -130,7 +130,7 @@ def test_detect_gaps_arbitrary_period(
 ):
     """Checks that DetectGaps correctly detects gaps with arbitrary window periods."""
 
-    gap_detector = GapDetector(threshold=threshold)
+    gap_detector = GapDetector(threshold=threshold, normalize_output=True)
 
     with _TestPipeline() as p:
         main_input = p | "CreateMessages" >> beam.Create(messages)
@@ -149,7 +149,7 @@ def test_detect_gaps_arbitrary_period(
 
         def check_output(gaps):
             assert len(gaps) == expected_gaps
-            gaps = sorted(gaps, key=lambda x: x["OFF"]["timestamp"])
+            gaps = sorted(gaps, key=lambda x: x["start_timestamp"])
 
         assert_that(output, check_output)
 
@@ -265,7 +265,7 @@ def test_detect_closing_gaps(
 def test_detect_positions_hours_before(messages, threshold, date_range, expected_gaps):
     """Checks that the correct number of hours before a gap are computed."""
 
-    gap_detector = GapDetector(threshold=threshold)
+    gap_detector = GapDetector(threshold=threshold, normalize_output=True)
 
     with _TestPipeline() as p:
         main_input = p | "CreateMessages" >> beam.Create(messages)
@@ -274,7 +274,7 @@ def test_detect_positions_hours_before(messages, threshold, date_range, expected
             main_input
             | "DetectGaps" >> DetectGaps(
                 gap_detector=gap_detector,
-                eval_last=False,  # Matches original logic
+                eval_last=False,
                 window_period_d=1,
                 date_range=date_range,
                 side_inputs=None,
@@ -284,7 +284,7 @@ def test_detect_positions_hours_before(messages, threshold, date_range, expected
         def check_output(gaps):
             assert len(gaps) == len(expected_gaps)
 
-            gaps = sorted(gaps, key=lambda x: x["OFF"]["timestamp"])
+            gaps = sorted(gaps, key=lambda x: x["start_timestamp"])
 
             for gap, expected_gap in zip(gaps, expected_gaps):
                 for k in POSITIONS_HOURS_BEFORE_KEYS:
@@ -333,12 +333,13 @@ def get_dates_in_range(start_date, end_date):
 
 
 @pytest.mark.parametrize(
-    "messages, open_gaps, threshold, date_ranges, expected_gaps",
+    "messages, open_gaps, threshold, window_period_d, date_ranges, expected_gaps",
     [
         pytest.param(
             case["messages"],
             case["open_gaps"],
             case["threshold"],
+            case["window_period_d"],
             case["date_ranges"],
             case["expected_gaps"],
             id=case["id"]
@@ -346,7 +347,9 @@ def get_dates_in_range(start_date, end_date):
         for case in TestCases.INCREMENTAL_MODE
     ],
 )
-def test_incremental_mode(tmp_path, messages, open_gaps, threshold, date_ranges, expected_gaps):
+def test_incremental_mode(
+    tmp_path, messages, open_gaps, threshold, window_period_d, date_ranges, expected_gaps
+):
     gap_detector = GapDetector(threshold=threshold, normalize_output=True)
 
     # Mirrors the production gaps table - deleted from and appended to each run.
@@ -381,6 +384,7 @@ def test_incremental_mode(tmp_path, messages, open_gaps, threshold, date_ranges,
                     gap_detector=gap_detector,
                     date_range=[start_date_str, end_date_str],
                     eval_last=True,
+                    window_period_d=window_period_d,
                     side_inputs=side_inputs,
                 )
             )


### PR DESCRIPTION
## Problem

When processing a date range, closed gaps detected by **ProcessGroup** or **ProcessBoundaries** were not accompanied by an open version (v1), unlike daily processing which naturally creates one as an intermediate step.

This caused gaps to be **permanently lost** when a subsequent reprocess started after the OFF message but before the ON message: the delete query removed the closed gap, and no open v1 existed as a seed to reconstruct it.

## Root Cause

In daily processing, the pipeline evaluates each day independently. If a vessel goes dark long enough, an open gap is created on the OFF day (or a subsequent day with no messages), and closed the next time a message arrives. This guarantees that an open v1 always exists in the table before the closed v2 is written.

In range processing, the pipeline can see both the OFF and ON messages within the same run, producing a closed gap directly — skipping the open v1 entirely.

## Fix

For each closed gap detected during range processing, evaluate `eval_open_gap` against every day between the OFF and ON messages (excluding the ON day). If the condition is met on any of those days — mirroring what daily processing would have done — emit an open v1 alongside the closed v2.

This ensures range processing produces the same table state as daily processing, making gap reconstruction after any reprocess always possible.

## Testing

Added 4 test cases covering the two components and two edge cases for the OFF message timestamp:

- `recreate_gap_after_reprocess__boundaries_off_far_from_midnight`
- `recreate_gap_after_reprocess__boundaries_off_close_to_midnight`
- `recreate_gap_after_reprocess__group_off_far_from_midnight`
- `recreate_gap_after_reprocess__group_off_close_to_midnight`

---
https://globalfishingwatch.atlassian.net/browse/PIPELINE-3900