### PR TITLE
PIPELINE-3900: Fix wrong end_timestamp from close path on reprocessing

### DIFF
--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -17,15 +17,58 @@ class Boundaries:
     def __init__(self, boundaries):
         self._boundaries = sorted(boundaries, key=lambda x: x.first_message()["timestamp"])
 
-    def get_first_message_inside_range(self, date_range):
-        if date_range is not None:
-            start_ds = datetime_from_date(date_range[0]).timestamp()
-            for b in self._boundaries:
-                fm = b.first_message()
-                if fm["timestamp"] >= start_ds:
-                    return fm
+    def get_first_message_inside_range(self, date_range, off_ts=None):
+        """Returns the earliest boundary message at or after ``date_range[0]``.
 
-        return None
+        Used by the close path as the ON for an open precursor.
+
+        Two constraints decide what to return:
+
+        1. **Suppress when ProcessGroup will detect the gap directly.** If
+           ``off_ts`` is provided and there's a boundary whose
+           gap-detection zone (i.e. ``b.start[0].timestamp`` onwards)
+           includes ``off_ts`` *and* whose messages include something
+           at-or-after ``date_range[0]``, ProcessGroup will detect the
+           closed gap via its step-back path. Returning a message here
+           would let the close path emit a duplicate, and with the
+           ``version = on_m.timestamp`` scheme the wrong (later) end could
+           win in ``_last_versions``.
+        2. **Otherwise, return the earliest in-range message across ALL
+           boundary messages** (``b.start + b.end``), not just each
+           boundary's ``first_message()``. The original implementation only
+           inspected ``first_message()`` -- but the correct ON often lives
+           in an earlier boundary's ``end`` list while a later boundary's
+           ``first_message`` is much later, causing the close path to
+           produce a gap with a wrong ``end_timestamp``.
+
+        Args:
+            date_range: Run's ``[start, end)`` date range.
+            off_ts: ``open_gap.start_timestamp`` (the OFF). Optional; when
+                provided, enables the suppression in (1) and filters out
+                candidates at or before ``off_ts``.
+        """
+        if date_range is None:
+            return None
+        start_ds = datetime_from_date(date_range[0]).timestamp()
+
+        if off_ts is not None:
+            for b in self._boundaries:
+                if not b.start:
+                    continue
+                detection_zone_start = b.start[0][GapDetector.KEY_TIMESTAMP]
+                msgs = b.start + b.end
+                has_after = any(m[GapDetector.KEY_TIMESTAMP] >= start_ds for m in msgs)
+                if has_after and off_ts >= detection_zone_start:
+                    return None
+
+        candidates = (
+            m
+            for b in self._boundaries
+            for m in (b.start + b.end)
+            if m[GapDetector.KEY_TIMESTAMP] >= start_ds
+            and (off_ts is None or m[GapDetector.KEY_TIMESTAMP] > off_ts)
+        )
+        return min(candidates, key=lambda m: m[GapDetector.KEY_TIMESTAMP], default=None)
 
     def consecutive_boundaries(self):
         return list(zip(self._boundaries[:-1], self._boundaries[1:]))
@@ -115,7 +158,12 @@ class ProcessBoundaries(DoFn):
         # Step two.
         # If open gap exists, close it unless it was already detected in step one.
         open_gap = self._load_open_gap(side_inputs, key_value)
-        open_gap_on_m = boundaries.get_first_message_inside_range(self._date_range)
+        off_ts = (
+            open_gap[f"start_{self.KEY_TIMESTAMP}"] if open_gap is not None else None
+        )
+        open_gap_on_m = boundaries.get_first_message_inside_range(
+            self._date_range, off_ts=off_ts,
+        )
 
         if open_gap is not None and open_gap_on_m is not None:
             open_gap_id = open_gap[self.KEY_GAP_ID]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -674,5 +674,43 @@ class TestCases:
                 (utc_datetime(2020, 12, 28, 10, 0), None),
             ],
             "id": "recreate_gap_after_reprocess__boundaries_on_in_interior"
+        },
+        # Production-style scenario where the close path could pick a wrong ON.
+        # OFF (12-27 00:31) is in the gap-detection zone of window A
+        # ([12-26 12, 12-29 00), offset=12h). The correct ON (12-28 00:04) is
+        # inside window A's `end` list. A later message (12-28 13:00) lands in
+        # window B ([12-28 12, 12-31 00)). On daily-tail iter 2 with
+        # date_range=[12-28, 01-01) and the v1 seed surviving from iter 1,
+        # ProcessGroup correctly detects (OFF, ON) via step-back. If the
+        # close path also fires it would iterate boundaries by their
+        # ``first_message()``: B_A.first_message=12-27 00:05 (out of range,
+        # skip), B_B.first_message=12-28 13:00 (in range, return) -- wrong.
+        # The wrong closed gap then wins in _last_versions because its
+        # version (=on_m.timestamp) is later. ``get_first_message_inside_range``
+        # must return None here so the close path is suppressed.
+        {
+            "messages": {
+                "2020-12-27": [
+                    create_message(time=datetime(2020, 12, 27, 0, 5)),
+                    create_message(time=datetime(2020, 12, 27, 0, 31)),
+                ],
+                "2020-12-28": [
+                    create_message(time=datetime(2020, 12, 28, 0, 4)),
+                    create_message(time=datetime(2020, 12, 28, 13, 0)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 14,
+            "window_period_d": 2,
+            "date_ranges": [
+                ("2020-12-27", "2020-12-31"),
+                ("2020-12-28", "2021-01-01"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2020, 12, 27, 0, 31), None),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
+                (utc_datetime(2020, 12, 28, 13, 0), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_close_path_must_not_pick_later_window_message"
         }
     ]


### PR DESCRIPTION
## Summary

Builds on the PIPELINE-3900 fix merged in #119. While verifying that fix on real BigQuery data via the mode-equivalence integration test (branch `testing/orchestration_equivalence_integration_tests`), a second, related bug surfaced: 8 closed gaps in the test cohort had their `end_timestamp` shifted forward by 12-27 hours in incremental modes vs the range-mode oracle.

This PR addresses that `end_timestamp` mismatch.

## The bug

When the v1 open-precursor seed (added in #119) survives a daily-tail iteration's DELETE pre-hook (because its `start_timestamp` predates `date_range[0]`), `ProcessBoundaries` step 2 runs the close path against it. `Boundaries.get_first_message_inside_range` was iterating boundaries by their `first_message()` and returning the first one at-or-after `date_range[0]` — but for in-window gaps with the brief-resume-then-silence shape, the correct ON often lives in an *earlier* boundary's `end` list while the *next* boundary's `first_message()` is much later (next sliding-window cycle). Returning that later message produced a closed v2 with a wrong `end_timestamp`.

`ProcessGroup` separately emitted the correct closed v2 via its step-back path. Both rows landed in the raw table with the same `gap_id`. Because `version = on_m.timestamp`, the wrong row had a later version and won in `_last_versions`.

The dedup logic introduced in #119 (`if open_gap_id not in gaps`) is local to `ProcessBoundaries` and didn't see `ProcessGroup`'s emission, so the cross-stream duplicate persisted.

## Fix

Two changes to `Boundaries.get_first_message_inside_range`:

1. **Suppress when `ProcessGroup` will detect.** If the open precursor's OFF falls inside some boundary's gap-detection zone (`b.start[0].timestamp` onwards) and that boundary has any in-range message, return `None`. `ProcessGroup`'s step-back will detect the gap with the correct ON; the close path would just produce a duplicate.
2. **Otherwise, return the correct ON.** Iterate all boundary messages (`b.start + b.end`), filter to those at-or-after `date_range[0]` AND strictly after OFF, return the earliest. The original implementation only inspected `first_message()`, missing correct ONs that live in an earlier boundary's `end` list.

Caller passes `off_ts=open_gap.start_timestamp` so part 1 can fire.

## Evidence (real-BQ integration test)

Mode-equivalence test against AIS staging data (year 2020, 131 ssvids, 40,112 gaps), comparing each pair against the range-mode oracle `_1_bf`:

| State | `_1_bf vs _2_bfd` | `_1_bf vs _3_bftruncate` | `_1_bf vs _4_mutate_recover` |
|---|---|---|---|
| Before this PR (commit `c16b2c9`) | 8 wrong `end_timestamp` | same | same |
| With this PR | **0** ¹ | **0** ¹ | **0** ¹ |

¹ `end_timestamp`, `duration_h`, `implied_speed_knots`, `end_msgid`, `end_lat/lon`, `end_distance_*`, `end_seg_id`, `end_ais_class`, `end_receiver_type`, `version` all become identical between range-mode and incremental modes for the previously-affected 8 gaps.

## Known follow-up (not in this PR)

A separate, smaller issue surfaces *because of* this fix: 3 of the 8 previously-affected gaps now show `positions_hours_before*` mismatches (off by 17-29 positions) vs `_1_bf`. This is a pre-existing issue masked by the wrong-row-wins behavior — the messages-query buffer (1 calendar day) doesn't always cover the full `n_hours_before=12h` before OFF on iter 2 of daily-tail. A separate PR will address it. The close-path fix here is a strict improvement: previously these gaps had wrong `end_timestamp` *and* coincidentally-correct positions; now they have correct `end_timestamp` and slightly-truncated positions.

## Test plan

- [x] Unit tests pass (51, includes new fixture `recreate_gap_after_reprocess__boundaries_close_path_must_not_pick_later_window_message` that reproduces the production scenario)
- [x] Integration test: all 4 mode-equivalence pairs show `end_timestamp` IDENTICAL after this fix (was 8 mismatches before)
- [ ] Reviewer: confirm the suppression rule in `get_first_message_inside_range` doesn't over-suppress legitimate boundary-spanning gaps where ProcessGroup wouldn't detect (the existing `recreate_gap_after_reprocess__boundaries_subday_gap` fixture covers this case and still passes)