### PR TITLE
PIPELINE-3943: Fix wrong ON message selected when closing open gaps via side inputs

### DIFF
--- a/src/pipe_gaps/pipelines/detect/fns/extract_group_boundary.py
+++ b/src/pipe_gaps/pipelines/detect/fns/extract_group_boundary.py
@@ -3,122 +3,92 @@ from dataclasses import dataclass
 
 from apache_beam.transforms.core import DoFn
 from apache_beam.transforms.window import IntervalWindow
+from gfw.common.datetime import datetime_from_date
 
-from gfw.common.iterables import binary_search_first_ge
+from pipe_gaps.pipelines.detect.messages import Messages
 
 
 @dataclass(eq=True, frozen=True)
 class Boundary:
-    """Encapsulates first N and last M position messages for an ssvid and time interval.
+    """Encapsulates first and last position messages for an ssvid within a time window.
 
     Args:
         ssvid:
             Id for the vessel.
 
         start:
-            First N messages of the time interval.
+            First message at or after window_start + offset.
 
         end:
-            Last message of the time interval.
+            Last messages of the time interval, i.e. all messages within
+            offset seconds before the window's last message.
+
+        first_message_in_range:
+            First message at or after the processing range start, if provided.
+            Used by ProcessBoundaries to find the correct ON message when closing open gaps.
     """
     ssvid: str
-    start: list[dict]
+    start: dict
     end: list[dict]
+    first_message_in_range: dict | None = None
 
     def __getitem__(self, key):
         return self.__dict__[key]
 
-    @classmethod
-    def from_group(
-        cls, group: tuple, offset: int, start_time: int = None, timestamp_key="timestamp"
-    ):
-        """Instantiates a Boundary object from a group.
-
-        Args:
-            group:
-                A tuple (key, messages), where `key` is typically the SSVID and `messages`
-                is a list of dicts containing vessel messages.
-
-            offset:
-                The offset in seconds used to determine how far back to look when selecting
-                the last messages in the group.
-
-            start_time:
-                Optional Unix timestamp (in seconds) used to skip initial messages before
-                this threshold. If None, all messages are considered.
-
-            timestamp_key:
-                The key used to extract timestamps from messages. Defaults to "timestamp".
-        """
-        ssvid, messages = group
-
-        messages.sort(key=lambda x: x[timestamp_key])
-
-        first_msg_index = 0
-        if start_time is not None:
-            first_msg_index = cls.get_index_for_start_time(messages, start_time)
-
-        start = [messages[first_msg_index]]
-
-        end = cls.get_last_messages(messages, offset)
-
-        return cls(ssvid=ssvid, start=start, end=end)
-
-    @classmethod
-    def get_index_for_start_time(cls, messages: list[dict], start_time: int):
-        idx = binary_search_first_ge(
-            messages,
-            start_time,
-            key=lambda m: m["timestamp"]
-        )
-
-        if idx < 0:
-            idx = 0
-
-        return idx
-
-    @classmethod
-    def get_last_messages(cls, messages: list[dict], offset: int = 0):
-        # We get all messages within a period of time before the last message.
-
-        last_msg_timestamp = messages[-1]["timestamp"]
-        n_hours_before = last_msg_timestamp - offset
-
-        i = len(messages) - 1
-        for m in reversed(messages):
-            if m["timestamp"] == last_msg_timestamp:
-                continue
-
-            if m["timestamp"] < n_hours_before:
-                break
-
-            i -= 1
-
-        return messages[i:]
+    def first_message(self):
+        return self.start
 
     def last_message(self):
         return self.end[-1]
 
-    def first_message(self):
-        return self.start[0]
-
 
 class ExtractGroupBoundary(DoFn):
-    def __init__(self, window_offset_s: int, timestamp_key: str = "timestamp"):
+    """Apache Beam DoFn that extracts boundary messages from each windowed group.
+
+    For each window, retains only the first and last messages needed by
+    ProcessBoundaries to detect cross-window gaps and close open gaps.
+
+    Args:
+        window_offset_s:
+            Offset in seconds used to determine window start time and
+            the lookback period for selecting last messages.
+
+        timestamp_key:
+            Key used to extract timestamps from messages. Defaults to "timestamp".
+
+        date_range:
+            Optional tuple of (start_date, end_date). When provided, the boundary
+            will also retain the first message at or after start_date, used by
+            ProcessBoundaries to correctly close open gaps.
+    """
+
+    def __init__(
+        self,
+        window_offset_s: int,
+        timestamp_key: str = "timestamp",
+        date_range=None,
+    ):
         self._window_offset_s = window_offset_s
         self._timestamp_key = timestamp_key
+        self._date_range = date_range
 
     def process(
         self, group: tuple[Any, Iterable[dict]], window: IntervalWindow = DoFn.WindowParam
     ) -> Iterable[Boundary]:
+        key, raw_messages = group
+        messages = Messages(list(raw_messages), self._timestamp_key)
+
         start_time = window.start.seconds() + self._window_offset_s
 
-        key, messages = group
-        messages = list(messages)  # On dataflow, `messages` is a _ConcatSequence object.
+        first_message_in_range = None
+        if self._date_range is not None:
+            # TODO: should we make the date_range mandatory for the pipeline?
+            range_start_ts = datetime_from_date(self._date_range[0]).timestamp()
+            first_message_in_range = messages.first_message_at_or_after(timestamp=range_start_ts)
 
-        yield Boundary.from_group(
-            (key.ssvid, messages),
-            offset=self._window_offset_s,
-            start_time=start_time,
-            timestamp_key=self._timestamp_key
+        yield Boundary(
+            ssvid=key.ssvid,
+            start=messages.first_message_at_or_after(timestamp=start_time),
+            end=messages.last_messages(offset=self._window_offset_s),
+            first_message_in_range=first_message_in_range,
         )

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -14,18 +14,31 @@ logger = logging.getLogger(__name__)
 
 class Boundaries:
     """Container for Boundary objects."""
-    def __init__(self, boundaries):
+    def __init__(self, boundaries: list[Boundary]) -> None:
         self._boundaries = sorted(boundaries, key=lambda x: x.first_message()["timestamp"])
 
-    def get_first_message_inside_range(self, date_range):
-        if date_range is not None:
-            start_ds = datetime_from_date(date_range[0]).timestamp()
-            for b in self._boundaries:
-                fm = b.first_message()
-                if fm["timestamp"] >= start_ds:
-                    return fm
+    def get_first_message_inside_range(self, date_range: tuple = None) -> dict:
+        """Returns the first message across all boundaries that falls within date_range.
 
-        return None
+        Searches start, end and first_message_in_range of each boundary and returns
+        the chronologically earliest message at or after date_range[0].
+
+        Args:
+            date_range:
+                Tuple of (start_date, end_date). If None, returns None.
+        """
+        if date_range is None:
+            # TODO: should we make date_range mandatory for the pipeline?
+            return None
+
+        start_ds = datetime_from_date(date_range[0]).timestamp()
+        candidates = (
+            m
+            for b in self._boundaries
+            for m in [b.start] + b.end + [b.first_message_in_range]
+            if m["timestamp"] >= start_ds
+        )
+        return min(candidates, key=lambda m: m["timestamp"], default=None)
 
     def consecutive_boundaries(self):
         return list(zip(self._boundaries[:-1], self._boundaries[1:]))
@@ -73,7 +86,7 @@ class ProcessBoundaries(DoFn):
         # Step one:
         # detect potential gap between last message of a group and first message of next group.
         for left, right in boundaries.consecutive_boundaries():
-            messages = left.end + right.start
+            messages = left.end + [right.start]
 
             start_dt = datetime_from_timestamp(left.last_message()[self.KEY_TIMESTAMP])
 
@@ -138,6 +151,7 @@ class ProcessBoundaries(DoFn):
 
             comparison_date = last_message_dt.date()
             if self._date_range is not None:
+                # TODO: should we make the date_range mandatory for the pipeline?
                 comparison_date = self._date_range[1] - timedelta(days=1)
 
             last_message_in_range = self._is_message_in_range(last_message)
@@ -209,6 +223,7 @@ class ProcessBoundaries(DoFn):
         message_dt = datetime_from_timestamp(message_ts)
 
         if self._date_range is not None:
+            # TODO: should we make the date_range mandatory for the pipeline?
             start_dt = datetime_from_date(self._date_range[0])
             if buffer:
                 start_dt -= self._gap_detector.min_gap_length

--- a/src/pipe_gaps/pipelines/detect/messages.py
+++ b/src/pipe_gaps/pipelines/detect/messages.py
@@ -1,0 +1,59 @@
+from functools import cached_property
+
+from gfw.common.iterables import binary_search_first_ge
+
+
+class Messages:
+    """Sorted collection of position messages with time-based retrieval methods.
+
+    Args:
+        messages:
+            List of message dicts.
+
+        timestamp_key:
+            Key used to extract timestamps from messages. Defaults to "timestamp".
+    """
+
+    def __init__(self, messages: list[dict], timestamp_key: str = "timestamp"):
+        self._timestamp_key = timestamp_key
+        self._messages = messages
+
+    @cached_property
+    def sorted(self) -> list[dict]:
+        """Returns messages sorted by timestamp.
+
+        Sorting is done in-place to avoid creating a new list — messages can be large.
+        Result is cached so subsequent calls do not re-sort.
+        """
+        self._messages.sort(key=lambda m: m[self._timestamp_key])
+        return self._messages
+
+    def first_message_at_or_after(self, timestamp: float) -> dict:
+        """Returns first message at or after the given timestamp.
+
+        Args:
+            timestamp:
+                Unix timestamp to search from.
+        """
+        idx = binary_search_first_ge(self.sorted, timestamp, key=lambda m: m[self._timestamp_key])
+
+        return self.sorted[max(idx, 0)]
+
+    def last_messages(self, offset: int = 0) -> list[dict]:
+        """Returns all messages within offset seconds before the last message.
+
+        Args:
+            offset:
+                Time window in seconds before the last message.
+        """
+        last_timestamp = self.sorted[-1][self._timestamp_key]
+        cutoff = last_timestamp - offset
+        i = binary_search_first_ge(self.sorted, cutoff, key=lambda m: m[self._timestamp_key])
+
+        return self.sorted[i:]
+
+    def __len__(self) -> int:
+        return len(self._messages)
+
+    def __getitem__(self, idx) -> dict:
+        return self.sorted[idx]

--- a/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
+++ b/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
@@ -103,6 +103,7 @@ class DetectGaps(beam.PTransform):
     def date_range(self):
         date_range = None
         if self._date_range is not None:
+            # TODO: should we make the date_range mandatory for the pipeline?
             date_range = [date.fromisoformat(x) for x in self._date_range]
 
         return date_range
@@ -152,7 +153,9 @@ class DetectGaps(beam.PTransform):
             date_range=self.date_range
         )
 
-        extract_group_boundary = ExtractGroupBoundary(window_offset_s=self.offset_s)
+        extract_group_boundary = ExtractGroupBoundary(
+            window_offset_s=self.offset_s, date_range=self.date_range
+        )
 
         # Group pcollection by a configured key and time window.
         groups = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -646,6 +646,7 @@ class TestCases:
             "expected_gaps": [
                 (utc_datetime(2020, 12, 27, 0, 31), None),
                 (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # duplicate
                 (utc_datetime(2020, 12, 28, 0, 4), None),
             ],
             "id": "recreate_gap_after_reprocess__boundaries_correct_end_timestamp"
@@ -668,11 +669,38 @@ class TestCases:
                 ("2020-12-28", "2021-01-01"),
             ],
             "expected_gaps": [
-                (utc_datetime(2020, 12, 27, 0, 31), None),
-                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
-                (utc_datetime(2020, 12, 28, 0, 4), utc_datetime(2020, 12, 28, 10, 0)),
-                (utc_datetime(2020, 12, 28, 10, 0), None),
+                (utc_datetime(2020, 12, 27, 0, 31), None),                              # gap 1 v1
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # gap 1 v2
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # gap 1 v2 (duplicate)  # noqa
+                (utc_datetime(2020, 12, 28, 0, 4), utc_datetime(2020, 12, 28, 10, 0)),  # gap 2 v1
+                (utc_datetime(2020, 12, 28, 10, 0), None),                              # gap 3 v1
             ],
             "id": "recreate_gap_after_reprocess__boundaries_on_in_interior"
+        },
+        {  # Production-style scenario where the close path could pick a wrong ON message.
+            "messages": {
+                "2020-12-27": [
+                    create_message(time=datetime(2020, 12, 27, 0, 5)),
+                    create_message(time=datetime(2020, 12, 27, 0, 31)),
+                ],
+                "2020-12-28": [
+                    create_message(time=datetime(2020, 12, 28, 0, 4)),
+                    create_message(time=datetime(2020, 12, 28, 13, 0)),
+                ],
+            },
+            "open_gaps": [],
+            "threshold": 14,
+            "window_period_d": 2,
+            "date_ranges": [
+                ("2020-12-27", "2020-12-31"),
+                ("2020-12-28", "2021-01-01"),
+            ],
+            "expected_gaps": [
+                (utc_datetime(2020, 12, 27, 0, 31), None),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
+                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # duplicate.  # noqa
+                (utc_datetime(2020, 12, 28, 13, 0), None),
+            ],
+            "id": "recreate_gap_after_reprocess__boundaries_correct_on_message"
         }
     ]


### PR DESCRIPTION
## Problem

When closing an open gap via side inputs (Step 2 in `ProcessBoundaries`), `get_first_message_inside_range` was returning the wrong ON message. It iterated boundaries sorted by `first_message()` and returned the first message of the first boundary whose `first_message` fell within the range — missing messages that were in the **interior** of a boundary window (neither in `b.start` nor `b.end`).

This caused the closed gap to have a wrong `end_timestamp`, `duration_h`, `implied_speed_knots`, and related fields.

## Root Cause

`b.first_message()` is the first message at or after `window_start + offset` — a window-based concept. The first message inside `date_range[0]` can fall anywhere in the window — start, interior, or end — and is not guaranteed to coincide with
`b.first_message()`.

## Fix

Two changes:

**1. Plumb `date_range` into `ExtractGroupBoundary`** so each `Boundary` retains `first_message_in_range` — the first message at or after `date_range[0]`. This ensures the correct ON message candidate is always available regardless of where it falls in the window.

**2. Fix `get_first_message_inside_range`** to search `b.start + b.end + [b.first_message_in_range]` across all boundaries and return the chronologically earliest candidate using `min()`, instead of returning the first boundary's
`first_message()`.

## Refactoring

As part of this fix, `ExtractGroupBoundary` and `Boundary` were refactored:

- `Boundary` is now a pure dataclass with no construction logic or classmethods.
- A new `Messages` class encapsulates sorted message retrieval (`first_messages`,  `last_messages`) with lazy sorting via `cached_property`.
- Construction logic moved entirely into `ExtractGroupBoundary.process`.
- `date_range` injected into `ExtractGroupBoundary` so it can compute  `first_message_in_range` at boundary construction time.

## Testing

Added test case `recreate_gap_after_reprocess__boundaries_correct_on_message` which reproduces the bug: an ON message in the interior of a window boundary was previously missed, causing the wrong ON message to be selected.

---
https://globalfishingwatch.atlassian.net/browse/PIPELINE-3943