### PR TITLE
PIPELINE-3945: Fix duplicate gaps detected both in groups and boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "pipe-gaps"
-version = "0.9.5"
+version = "0.9.6"
 description = "Tools for detecting interruptions in vessel position reporting systems (e.g., AIS, VMS)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "Tools for detecting interruptions in vessel position reporting sy
 readme = "README.md"
 license = "Apache-2.0"
 authors = [
-    { name = "Tomás J. Link", email = "tomas.link@globalfishingwatch.org" },
+    { name = "GFW Engineering Team", email = "engineering-team@globalfishingwatch.org" },
 ]
 maintainers = [
     { name = "Tomás J. Link", email = "tomas.link@globalfishingwatch.org" },

--- a/src/pipe_gaps/common/beam/side_inputs.py
+++ b/src/pipe_gaps/common/beam/side_inputs.py
@@ -1,0 +1,54 @@
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SideInputs:
+    """Wraps Beam MultiMap side inputs and provides keyed value lookup.
+
+    Args:
+        side_inputs:
+            Beam MultiMap side input.
+    """
+
+    def __init__(self, side_inputs: Any) -> None:
+        self._side_inputs = side_inputs
+
+    def get(self, key: Any) -> list[Any]:
+        """Returns all values for the given key, or empty list if not found.
+
+        Args:
+            key:
+                Key to look up in the side inputs.
+        """
+        try:
+            values = list(self._side_inputs[key])
+        except KeyError:
+            logger.debug("Key {} was not found in side inputs.".format(key))
+            return []
+
+        if not values:
+            logger.debug("No values found for key {}.".format(key))
+            return []
+
+        if not isinstance(values[0], dict):
+            # beam.MultiMap encapsulates value in an iterable of iterables (wtf?).
+            values = [list(v)[0] for v in values]
+
+        return values
+
+    def get_first(self, key: Any) -> Any | None:
+        """Returns the first value for the given key, or None if not found.
+
+        Args:
+            key:
+                Key to look up in the side inputs.
+        """
+        first = None
+
+        values = self.get(key)
+        if values:
+            first = values[0]
+
+        return first

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -58,6 +58,7 @@ from geopy.distance import geodesic
 
 from gfw.common.dictionaries import copy_dict_without
 from gfw.common.iterables import binary_search_first_ge
+from gfw.common.datetime import datetime_from_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -460,3 +461,20 @@ class GapDetector:
         }
 
         return off_on_messages
+
+    @classmethod
+    def debug_gap(cls, g: dict):
+        try:
+            start_ts = g["OFF"][cls.KEY_TIMESTAMP]
+            end_ts = g["ON"][cls.KEY_TIMESTAMP]
+        except KeyError:
+            start_ts = g[f"start_{cls.KEY_TIMESTAMP}"]
+            end_ts = g.get(f"end_{cls.KEY_TIMESTAMP}")
+
+        start_dt = datetime_from_timestamp(start_ts)
+        end_dt = datetime_from_timestamp(end_ts) if end_ts is not None else None
+
+        logger.debug("----------------------------------")
+        logger.debug("Gap OFF: {}".format(start_dt))
+        logger.debug("Gap  ON: {}".format(end_dt))
+        logger.debug("----------------------------------")

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -326,6 +326,8 @@ class GapDetector:
             previous_positions = chain(previous_positions, [off_m])
 
             count = self._count_messages_before_gap(previous_positions)
+            logger.debug(f"COUNT OF PREVIOUS POSSITIONS: {count}")
+
             gap[self.KEY_HOURS_BEFORE] = count[self.KEY_TOTAL]
             gap[self.KEY_HOURS_BEFORE_TER] = count[self.KEY_TERRESTRIAL]
             gap[self.KEY_HOURS_BEFORE_SAT] = count[self.KEY_SATELLITE]

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -7,6 +7,7 @@ from gfw.common.datetime import datetime_from_timestamp, datetime_from_date
 
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
+from pipe_gaps.common.beam.side_inputs import SideInputs
 from pipe_gaps.pipelines.detect.fns.extract_group_boundary import Boundary
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ class ProcessBoundaries(DoFn):
     def process(
         self,
         group: tuple[Any, Iterable[Boundary]],
-        side_inputs: Optional[dict[Any, Iterable]] = None
+        side_inputs: Optional[SideInputs] = None
     ) -> Iterable[dict]:
         key_value, boundaries_it = group
 
@@ -127,7 +128,7 @@ class ProcessBoundaries(DoFn):
 
         # Step two.
         # If open gap exists, close it unless it was already detected in step one.
-        open_gap = self._load_open_gap(side_inputs, key_value)
+        open_gap = SideInputs(side_inputs).get_first(key_value) if side_inputs else None
         open_gap_on_m = boundaries.get_first_message_inside_range(self._date_range)
 
         if open_gap is not None and open_gap_on_m is not None:
@@ -178,32 +179,6 @@ class ProcessBoundaries(DoFn):
         for versions in gaps.values():
             for g in versions:
                 yield g
-
-    def _load_open_gap(self, side_inputs, key):
-        side_inputs_list = self._load_side_inputs(side_inputs, key)
-
-        if len(side_inputs_list) > 0:
-            open_gap = side_inputs_list[0]
-
-            if not isinstance(open_gap, dict):
-                # beam.MultiMap encapsulates value in an iterable of iterables (wtf?).
-                open_gap = [x for x in open_gap][0]
-
-            return open_gap
-        else:
-            logger.debug("Open gap was not found for key {}.".format(key))
-
-        return None
-
-    def _load_side_inputs(self, side_inputs, key):
-        side_inputs_list = []
-        if side_inputs is not None:
-            try:
-                side_inputs_list = list(side_inputs[key])
-            except KeyError:
-                logger.debug("Key {} was not found in side inputs.".format(key))
-
-        return side_inputs_list
 
     def _close_open_gap(self, open_gap, on_m):
         off_m = self._gap_detector.off_message_from_gap(open_gap)

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -75,7 +75,7 @@ class ProcessBoundaries(DoFn):
     def process(
         self,
         group: tuple[Any, Iterable[Boundary]],
-        side_inputs: Optional[SideInputs] = None
+        side_inputs: Optional[dict[Any, Iterable]] = None
     ) -> Iterable[dict]:
         key_value, boundaries_it = group
 

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -99,7 +99,7 @@ class ProcessBoundaries(DoFn):
                 gap_id = g[self.KEY_GAP_ID]
 
                 gaps.setdefault(gap_id, []).append(g)
-                self._debug_gap(g)
+                self._gap_detector.debug_gap(g)
 
                 # Emit open version if daily mode would have created one.
                 # This ensures range processing produces the same table state as daily processing,
@@ -123,7 +123,7 @@ class ProcessBoundaries(DoFn):
                         gap_id=gap_id,
                         base_gap=self._gap_detector.previous_positions_from_gap(g))
 
-                    self._debug_gap(open_gap)
+                    self._gap_detector.debug_gap(open_gap)
                     gaps[gap_id].append(open_gap)
 
         # Step two.
@@ -140,7 +140,7 @@ class ProcessBoundaries(DoFn):
 
                 closed_gap = self._close_open_gap(open_gap, open_gap_on_m)
                 gaps[open_gap_id] = [closed_gap]
-                self._debug_gap(closed_gap)
+                self._gap_detector.debug_gap(closed_gap)
 
         # Step three:
         # Create open gap if last message of last group met condition.
@@ -171,7 +171,7 @@ class ProcessBoundaries(DoFn):
                     previous_positions=last_boundary.end[:-1]
                 )
                 gaps[new_open_gap[self.KEY_GAP_ID]] = [new_open_gap]
-                self._debug_gap(new_open_gap)
+                self._gap_detector.debug_gap(new_open_gap)
 
         total = sum(len(versions) for versions in gaps.values())
         logger.debug(f"Found {total} gap(s) for boundaries {formatted_key}...")
@@ -206,23 +206,3 @@ class ProcessBoundaries(DoFn):
             return message_dt >= start_dt
 
         return True
-
-    def _debug_gap(self, g: dict):
-        # TODO: move this elsewhere. It is duplicated.
-        end_dt = None
-
-        try:
-            start_ts = g["OFF"][self.KEY_TIMESTAMP]
-            end_ts = g["ON"][self.KEY_TIMESTAMP]
-        except KeyError:
-            start_ts = g[f"start_{self.KEY_TIMESTAMP}"]
-            end_ts = g[f"end_{self.KEY_TIMESTAMP}"]
-
-        start_dt = datetime_from_timestamp(start_ts)
-        if end_ts is not None:
-            end_dt = datetime_from_timestamp(end_ts)
-
-        logger.debug("----------------------------------")
-        logger.debug("Gap OFF: {}".format(start_dt))
-        logger.debug("Gap  ON: {}".format(end_dt))
-        logger.debug("----------------------------------")

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -10,6 +10,7 @@ from gfw.common.iterables import binary_search_first_ge
 
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
+from pipe_gaps.common.beam.side_inputs import SideInputs
 
 logger = logging.getLogger(__name__)
 
@@ -108,11 +109,10 @@ class ProcessGroup(DoFn):
             # Don't yield gap if OFF is before range start AND an open gap exists
             # in side inputs — ProcessBoundaries Step 2 will close it.
             # This avoids dupicates.
-            open_gap_for_key = self._load_open_gap(side_inputs, key)
+            open_gap = SideInputs(side_inputs).get_first(key) if side_inputs else None
             is_handled_by_process_boundaries = (
-                is_before_range and
-                open_gap_for_key is not None and
-                open_gap_for_key[self.KEY_GAP_ID] == gap[self.KEY_GAP_ID]
+                is_before_range and open_gap is not None and
+                open_gap[self.KEY_GAP_ID] == gap[self.KEY_GAP_ID]
             )
 
             if not is_handled_by_process_boundaries:
@@ -124,32 +124,6 @@ class ProcessGroup(DoFn):
             time.timestamp(),
             key=lambda m: m[self.KEY_TIMESTAMP]
         )
-
-    def _load_open_gap(self, side_inputs, key):
-        side_inputs_list = self._load_side_inputs(side_inputs, key)
-
-        if len(side_inputs_list) > 0:
-            open_gap = side_inputs_list[0]
-
-            if not isinstance(open_gap, dict):
-                # beam.MultiMap encapsulates value in an iterable of iterables (wtf?).
-                open_gap = [x for x in open_gap][0]
-
-            return open_gap
-        else:
-            logger.debug("Open gap was not found for key {}.".format(key))
-
-        return None
-
-    def _load_side_inputs(self, side_inputs, key):
-        side_inputs_list = []
-        if side_inputs is not None:
-            try:
-                side_inputs_list = list(side_inputs[key])
-            except KeyError:
-                logger.debug("Key {} was not found in side inputs.".format(key))
-
-        return side_inputs_list
 
     def _debug_gap(self, g: dict):
         # TODO: move this elsewhere. It is duplicated.

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -50,7 +50,10 @@ class ProcessGroup(DoFn):
 
             start_idx = self._get_index_for_time(messages, range_start_time)
             if start_idx > 0:
-                # To also evaluate first message with previous one
+                # Step back one message to include context from before the range boundary.
+                # This only applies to the first window, which has no previous boundary.
+                # Subsequent windows will evaluate this previous message in ProcessBoundaries.
+                # So no duplicate should appear from this.
                 start_idx = start_idx - 1
 
             effective_start_time = datetime_from_timestamp(messages[start_idx][self.KEY_TIMESTAMP])

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -76,7 +76,7 @@ class ProcessGroup(DoFn):
         )
 
         for gap in gaps:
-            self._debug_gap(gap)
+            self._gd.debug_gap(gap)
 
             # Emit open version if daily mode would have created one on any day between OFF and ON.
             # This ensures range processing produces the same table state as daily processing,
@@ -103,7 +103,7 @@ class ProcessGroup(DoFn):
                     gap_id=gap[self.KEY_GAP_ID],
                     base_gap=self._gd.previous_positions_from_gap(gap))
 
-                self._debug_gap(open_gap)
+                self._gd.debug_gap(open_gap)
                 yield open_gap
 
             # Don't yield gap if OFF is before range start AND an open gap exists
@@ -124,20 +124,3 @@ class ProcessGroup(DoFn):
             time.timestamp(),
             key=lambda m: m[self.KEY_TIMESTAMP]
         )
-
-    def _debug_gap(self, g: dict):
-        # TODO: move this elsewhere. It is duplicated.
-        try:
-            start_ts = g["OFF"][self.KEY_TIMESTAMP]
-            end_ts = g["ON"][self.KEY_TIMESTAMP]
-        except KeyError:
-            start_ts = g[f"start_{self.KEY_TIMESTAMP}"]
-            end_ts = g.get(f"end_{self.KEY_TIMESTAMP}")
-
-        start_dt = datetime_from_timestamp(start_ts)
-        end_dt = datetime_from_timestamp(end_ts) if end_ts is not None else None
-
-        logger.debug("----------------------------------")
-        logger.debug("Gap OFF: {}".format(start_dt))
-        logger.debug("Gap  ON: {}".format(end_dt))
-        logger.debug("----------------------------------")

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Any
+from typing import Iterable, Any, Optional
 from datetime import timedelta, date
 
 from apache_beam import DoFn
@@ -32,7 +32,10 @@ class ProcessGroup(DoFn):
         self._date_range = date_range
 
     def process(
-        self, group: tuple[Any, Iterable[dict]], window: IntervalWindow = DoFn.WindowParam
+        self,
+        group: tuple[Any, Iterable[dict]],
+        window: IntervalWindow = DoFn.WindowParam,
+        side_inputs: Optional[dict[Any, Iterable]] = None
     ):
         key, messages = group
 
@@ -89,7 +92,7 @@ class ProcessGroup(DoFn):
                 for i in range(days_spanned)
             )
 
-            # Don't emit open v1 if OFF is before range start - it's handled via side inputs.
+            # Don't emit open v1 if OFF is before range start - it's handled via ProcessBoundaries.
             is_before_range = self._date_range is not None and off_m_ts < range_start_time
 
             if should_emit_open and not is_before_range:
@@ -102,7 +105,18 @@ class ProcessGroup(DoFn):
                 self._debug_gap(open_gap)
                 yield open_gap
 
-            yield gap
+            # Don't yield gap if OFF is before range start AND an open gap exists
+            # in side inputs — ProcessBoundaries Step 2 will close it.
+            # This avoids dupicates.
+            open_gap_for_key = self._load_open_gap(side_inputs, key)
+            is_handled_by_process_boundaries = (
+                is_before_range and
+                open_gap_for_key is not None and
+                open_gap_for_key[self.KEY_GAP_ID] == gap[self.KEY_GAP_ID]
+            )
+
+            if not is_handled_by_process_boundaries:
+                yield gap
 
     def _get_index_for_time(self, messages: list, time):
         return binary_search_first_ge(
@@ -110,6 +124,32 @@ class ProcessGroup(DoFn):
             time.timestamp(),
             key=lambda m: m[self.KEY_TIMESTAMP]
         )
+
+    def _load_open_gap(self, side_inputs, key):
+        side_inputs_list = self._load_side_inputs(side_inputs, key)
+
+        if len(side_inputs_list) > 0:
+            open_gap = side_inputs_list[0]
+
+            if not isinstance(open_gap, dict):
+                # beam.MultiMap encapsulates value in an iterable of iterables (wtf?).
+                open_gap = [x for x in open_gap][0]
+
+            return open_gap
+        else:
+            logger.debug("Open gap was not found for key {}.".format(key))
+
+        return None
+
+    def _load_side_inputs(self, side_inputs, key):
+        side_inputs_list = []
+        if side_inputs is not None:
+            try:
+                side_inputs_list = list(side_inputs[key])
+            except KeyError:
+                logger.debug("Key {} was not found in side inputs.".format(key))
+
+        return side_inputs_list
 
     def _debug_gap(self, g: dict):
         # TODO: move this elsewhere. It is duplicated.

--- a/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
+++ b/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
@@ -11,10 +11,7 @@ from apache_beam.pvalue import PCollection
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
 
-from gfw.common.beam.transforms import (
-    ApplySlidingWindows,
-    GroupBy,
-)
+from gfw.common.beam.transforms import ApplySlidingWindows, GroupBy
 
 from pipe_gaps.common.beam.transforms import FilterWindowsByDateRange
 from pipe_gaps.pipelines.detect.fns.process_group import ProcessGroup

--- a/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
+++ b/src/pipe_gaps/pipelines/detect/transforms/detect_gaps.py
@@ -185,7 +185,7 @@ class DetectGaps(beam.PTransform):
 
         # Process the interior the groups
         output_in_groups = groups | "ProcessGroups" >> (
-            beam.ParDo(process_group)
+            beam.ParDo(process_group, side_inputs=side_inputs)
             | "GlobalWindow" >> beam.WindowInto(beam.window.GlobalWindows())
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -646,7 +646,6 @@ class TestCases:
             "expected_gaps": [
                 (utc_datetime(2020, 12, 27, 0, 31), None),
                 (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
-                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # duplicate
                 (utc_datetime(2020, 12, 28, 0, 4), None),
             ],
             "id": "recreate_gap_after_reprocess__boundaries_correct_end_timestamp"
@@ -671,7 +670,6 @@ class TestCases:
             "expected_gaps": [
                 (utc_datetime(2020, 12, 27, 0, 31), None),                              # gap 1 v1
                 (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # gap 1 v2
-                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # gap 1 v2 (duplicate)  # noqa
                 (utc_datetime(2020, 12, 28, 0, 4), utc_datetime(2020, 12, 28, 10, 0)),  # gap 2 v1
                 (utc_datetime(2020, 12, 28, 10, 0), None),                              # gap 3 v1
             ],
@@ -698,7 +696,6 @@ class TestCases:
             "expected_gaps": [
                 (utc_datetime(2020, 12, 27, 0, 31), None),
                 (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),
-                (utc_datetime(2020, 12, 27, 0, 31), utc_datetime(2020, 12, 28, 0, 4)),  # duplicate.  # noqa
                 (utc_datetime(2020, 12, 28, 13, 0), None),
             ],
             "id": "recreate_gap_after_reprocess__boundaries_correct_on_message"


### PR DESCRIPTION
## Problem

Duplicate closed gaps were written to the table when a surviving open v1 from a previous run was present. Only gaps whose OFF message is before `range_start` are affected — these survive the delete query and are passed as side inputs to `ProcessBoundaries` Step 2. At the same time, `ProcessGroup` step-back re-detects the same gap — both emitting identical `(gap_id, version)` rows in the same run.

## Fix

In `ProcessGroup.process`, skip yielding a gap when its OFF message is before `range_start` AND a surviving open gap exists in side inputs for that specific `gap_id`. In that case `ProcessBoundaries` Step 2 owns the gap. If no side input exists (first run), `ProcessGroup` yields normally.

## Refactoring

Introduced a generic `SideInputs` class to encapsulate Beam MultiMap lookup logic (`get` and `get_first`), replacing duplicated `_load_open_gap` / `_load_side_inputs` methods in both `ProcessGroup` and `ProcessBoundaries`.

---
https://globalfishingwatch.atlassian.net/browse/PIPELINE-3945