### PR TITLE
MAP-1676: Fix gaps below minimum length produced during reprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "pipe-gaps"
-version = "0.10.0"
+version = "0.10.1"
 description = "Tools for detecting interruptions in vessel position reporting systems (e.g., AIS, VMS)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/pipe_gaps/assets/queries/gaps.sql.j2
+++ b/src/pipe_gaps/assets/queries/gaps.sql.j2
@@ -29,3 +29,7 @@ WHERE
       AND NOT is_closed
     {% endif %}
   {% endif %}
+
+  {% if min_gap_length is not none %}
+    AND duration_h > {{ min_gap_length }}
+  {% endif %}

--- a/src/pipe_gaps/pipelines/detect/config.py
+++ b/src/pipe_gaps/pipelines/detect/config.py
@@ -60,6 +60,7 @@ class DetectGapsConfig(PipelineConfig):
                 version=self.version,
                 relevant_params=self.bq_output_gaps_description_params
             ),
+            min_gap_length=self.min_gap_length,
         )
 
     @property

--- a/src/pipe_gaps/pipelines/detect/table_config.py
+++ b/src/pipe_gaps/pipelines/detect/table_config.py
@@ -40,13 +40,19 @@ class GapsTableConfig(TableConfig):
     partition_field: str = "start_timestamp"
     clustering_fields: tuple = ("is_closed", "version", "ssvid")
 
+    # View parameter: gaps below this threshold are filtered from the last_versions view
+    # to exclude invalid gaps produced during reprocessing with new data.
+    # TODO: Consider accepting kwargs in create_view_hook so we can pass this parameter there
+    # instead of making it an instance variable of this config.
+    min_gap_length: Optional[float] = None
+
     @property
     def schema(self):
         return schemas.get_schema(self.schema_file)
 
     def view_query(self):
         """Returns a rendered query to create a view of this table."""
-        return GapsQuery(source_gaps=self.table_id).render()
+        return GapsQuery(source_gaps=self.table_id, min_gap_length=self.min_gap_length).render()
 
     def delete_query(self, start_date: date, end_date: Optional[date] = None) -> str:
         """Returns a rendered query to truncate gaps from start_date."""

--- a/src/pipe_gaps/queries/gaps.py
+++ b/src/pipe_gaps/queries/gaps.py
@@ -74,6 +74,9 @@ class GapsQuery(Query):
                 - only closed gaps (True),
                 - only open gaps (False)
                 - both (None).
+
+        min_gap_length:
+            If provided, filter out gaps whose duration_h is <= this threshold (in hours).
     """
 
     NAME = "gaps"
@@ -85,13 +88,15 @@ class GapsQuery(Query):
         end_date: Optional[date] = None,
         ssvids: Sequence[str] = (),
         is_closed: Optional[bool] = None,
-        use_timestamp: bool = False
+        use_timestamp: bool = False,
+        min_gap_length: Optional[float] = None,
     ) -> None:
         self._start_date = start_date
         self._end_date = end_date
         self._source_gaps = source_gaps
         self._ssvids = ssvids
         self._is_closed = is_closed
+        self._min_gap_length = min_gap_length
         # TODO: consider another design: this is an external parameter not pass to the query.
         self._use_timestamp = use_timestamp
 
@@ -120,4 +125,5 @@ class GapsQuery(Query):
             "start_date": start_date,
             "end_date": end_date,
             "is_closed": self._is_closed,
+            "min_gap_length": self._min_gap_length,
         }


### PR DESCRIPTION
Filter sub-threshold gaps from the last_versions view using the existing min-gap-length parameter, to exclude invalid gaps produced when reprocessing closes open gaps with new data that no longer satisfies the minimum duration.