### PR TITLE
PIPELINE-4050: Fix non-deterministic output on messages with tied timestamps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "pipe-gaps"
-version = "0.10.1"
+version = "0.10.2"
 description = "Tools for detecting interruptions in vessel position reporting systems (e.g., AIS, VMS)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/pipe_gaps/common/sorting.py
+++ b/src/pipe_gaps/common/sorting.py
@@ -1,8 +1,12 @@
 """Canonical ordering helpers."""
+from __future__ import annotations
+
+from operator import itemgetter
+from typing import Any
 
 
-def timestamp_msgid_key(message: dict, timestamp_key: str = "timestamp") -> tuple:
-    """Total-order sort key for position messages: ``(timestamp, msgid)``.
+def timestamp_msgid_key(timestamp_key: str = "timestamp") -> itemgetter[tuple[Any, ...]]:
+    """Return a key callable for the total order ``(timestamp, msgid)``.
 
     Position messages are sorted and selected (first-at-or-after, min-in-range,
     boundary ordering) in several places across the detect pipeline. Sorting by
@@ -22,13 +26,10 @@ def timestamp_msgid_key(message: dict, timestamp_key: str = "timestamp") -> tupl
     on every run and on every code path that picks from the same candidates.
 
     Args:
-        message:
-            Position message dictionary.
-
         timestamp_key:
             Key under which the message stores its unix timestamp.
 
     Returns:
-        Tuple usable as a ``key`` for ``sort``/``sorted``/``min``/``max``.
+        Callable usable as a ``key`` for ``sort``/``sorted``/``min``/``max``.
     """
-    return (message[timestamp_key], message["msgid"])
+    return itemgetter(timestamp_key, "msgid")

--- a/src/pipe_gaps/common/sorting.py
+++ b/src/pipe_gaps/common/sorting.py
@@ -1,0 +1,37 @@
+"""Canonical message ordering helpers.
+
+Position messages are sorted and selected (first-at-or-after, min-in-range,
+boundary ordering) in several places across the detect pipeline. Sorting by
+``timestamp`` alone is not a total order: a vessel can emit multiple messages
+with the same timestamp (e.g. through different receivers or segments), and
+for tied timestamps Python's stable sort preserves the INPUT order -- which,
+for messages read from BigQuery, is non-deterministic across runs.
+
+That non-determinism propagates into which message becomes a gap's OFF/ON
+endpoint, and from there into ``gap_id`` (a hash over the OFF message's
+ssvid/timestamp/lat/lon) and every ``end_*`` output field -- producing
+run-to-run diffs on identical input data.
+
+``message_sort_key`` defines the canonical total order ``(timestamp, msgid)``.
+``msgid`` is unique per message and present on every pipeline path (it is a
+mandatory field of the messages query schema), so ties resolve identically
+on every run and on every code path that picks from the same candidates.
+"""
+
+
+def message_sort_key(message: dict, timestamp_key: str = "timestamp") -> tuple:
+    """Total-order sort key for position messages: ``(timestamp, msgid)``.
+
+    Args:
+        message:
+            Position message dictionary.
+
+        timestamp_key:
+            Key under which the message stores its unix timestamp.
+
+    Returns:
+        Tuple usable as a ``key`` for ``sort``/``sorted``/``min``/``max``.
+        Messages missing ``msgid`` (not expected on pipeline paths) sort
+        by timestamp with an empty-string tiebreaker.
+    """
+    return (message[timestamp_key], message.get("msgid") or "")

--- a/src/pipe_gaps/common/sorting.py
+++ b/src/pipe_gaps/common/sorting.py
@@ -1,26 +1,25 @@
-"""Canonical message ordering helpers.
-
-Position messages are sorted and selected (first-at-or-after, min-in-range,
-boundary ordering) in several places across the detect pipeline. Sorting by
-``timestamp`` alone is not a total order: a vessel can emit multiple messages
-with the same timestamp (e.g. through different receivers or segments), and
-for tied timestamps Python's stable sort preserves the INPUT order -- which,
-for messages read from BigQuery, is non-deterministic across runs.
-
-That non-determinism propagates into which message becomes a gap's OFF/ON
-endpoint, and from there into ``gap_id`` (a hash over the OFF message's
-ssvid/timestamp/lat/lon) and every ``end_*`` output field -- producing
-run-to-run diffs on identical input data.
-
-``message_sort_key`` defines the canonical total order ``(timestamp, msgid)``.
-``msgid`` is unique per message and present on every pipeline path (it is a
-mandatory field of the messages query schema), so ties resolve identically
-on every run and on every code path that picks from the same candidates.
-"""
+"""Canonical ordering helpers."""
 
 
-def message_sort_key(message: dict, timestamp_key: str = "timestamp") -> tuple:
+def timestamp_msgid_key(message: dict, timestamp_key: str = "timestamp") -> tuple:
     """Total-order sort key for position messages: ``(timestamp, msgid)``.
+
+    Position messages are sorted and selected (first-at-or-after, min-in-range,
+    boundary ordering) in several places across the detect pipeline. Sorting by
+    ``timestamp`` alone is not a total order: a vessel can emit multiple messages
+    with the same timestamp (e.g. through different receivers or segments), and
+    for tied timestamps Python's stable sort preserves the INPUT order -- which,
+    for messages read from BigQuery, is non-deterministic across runs.
+
+    That non-determinism propagates into which message becomes a gap's OFF/ON
+    endpoint, and from there into ``gap_id`` (a hash over the OFF message's
+    ssvid/timestamp/lat/lon) and every ``end_*`` output field -- producing
+    run-to-run diffs on identical input data.
+
+    ``timestamp_msgid_key`` defines the canonical total order ``(timestamp, msgid)``.
+    ``msgid`` is unique per message and present on every pipeline path (it is a
+    mandatory field of the messages query schema), so ties resolve identically
+    on every run and on every code path that picks from the same candidates.
 
     Args:
         message:
@@ -31,7 +30,5 @@ def message_sort_key(message: dict, timestamp_key: str = "timestamp") -> tuple:
 
     Returns:
         Tuple usable as a ``key`` for ``sort``/``sorted``/``min``/``max``.
-        Messages missing ``msgid`` (not expected on pipeline paths) sort
-        by timestamp with an empty-string tiebreaker.
     """
-    return (message[timestamp_key], message.get("msgid") or "")
+    return (message[timestamp_key], message["msgid"])

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -46,7 +46,6 @@ Raises:
 """
 import logging
 import hashlib
-import operator
 from itertools import chain, pairwise
 from collections import defaultdict
 
@@ -59,6 +58,8 @@ from geopy.distance import geodesic
 from gfw.common.dictionaries import copy_dict_without
 from gfw.common.iterables import binary_search_first_ge
 from gfw.common.datetime import datetime_from_timestamp
+
+from pipe_gaps.common.sorting import message_sort_key
 
 logger = logging.getLogger(__name__)
 
@@ -384,8 +385,10 @@ class GapDetector:
 
     # @profile  # noqa  # Uncomment to run memory profiler
     def _sort_messages(self, messages: list) -> None:
-        key = operator.itemgetter(self.KEY_TIMESTAMP)
-        messages.sort(key=key)
+        # (timestamp, msgid) total order: timestamp alone is not unique, and
+        # tied messages would keep their (non-deterministic) input order,
+        # making OFF/ON picks -- and thus gap_id -- vary across runs.
+        messages.sort(key=lambda m: message_sort_key(m, self.KEY_TIMESTAMP))
 
     def _get_index_for_start_time(self, messages: list, start_time: datetime) -> Union[int, None]:
         return binary_search_first_ge(

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -385,7 +385,7 @@ class GapDetector:
 
     # @profile  # noqa  # Uncomment to run memory profiler
     def _sort_messages(self, messages: list) -> None:
-        messages.sort(key=lambda m: timestamp_msgid_key(m, self.KEY_TIMESTAMP))
+        messages.sort(key=timestamp_msgid_key(self.KEY_TIMESTAMP))
 
     def _get_index_for_start_time(self, messages: list, start_time: datetime) -> Union[int, None]:
         return binary_search_first_ge(

--- a/src/pipe_gaps/core/gap_detector.py
+++ b/src/pipe_gaps/core/gap_detector.py
@@ -59,7 +59,7 @@ from gfw.common.dictionaries import copy_dict_without
 from gfw.common.iterables import binary_search_first_ge
 from gfw.common.datetime import datetime_from_timestamp
 
-from pipe_gaps.common.sorting import message_sort_key
+from pipe_gaps.common.sorting import timestamp_msgid_key
 
 logger = logging.getLogger(__name__)
 
@@ -385,10 +385,7 @@ class GapDetector:
 
     # @profile  # noqa  # Uncomment to run memory profiler
     def _sort_messages(self, messages: list) -> None:
-        # (timestamp, msgid) total order: timestamp alone is not unique, and
-        # tied messages would keep their (non-deterministic) input order,
-        # making OFF/ON picks -- and thus gap_id -- vary across runs.
-        messages.sort(key=lambda m: message_sort_key(m, self.KEY_TIMESTAMP))
+        messages.sort(key=lambda m: timestamp_msgid_key(m, self.KEY_TIMESTAMP))
 
     def _get_index_for_start_time(self, messages: list, start_time: datetime) -> Union[int, None]:
         return binary_search_first_ge(

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -8,6 +8,7 @@ from gfw.common.datetime import datetime_from_timestamp, datetime_from_date
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
 from pipe_gaps.common.beam.side_inputs import SideInputs
+from pipe_gaps.common.sorting import message_sort_key
 from pipe_gaps.pipelines.detect.fns.extract_group_boundary import Boundary
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,13 @@ logger = logging.getLogger(__name__)
 class Boundaries:
     """Container for Boundary objects."""
     def __init__(self, boundaries: list[Boundary]) -> None:
-        self._boundaries = sorted(boundaries, key=lambda x: x.first_message()["timestamp"])
+        # (timestamp, msgid) total order on the first message: boundaries
+        # whose first messages tie on timestamp (e.g. different seg_ids of
+        # the same vessel) would otherwise keep their (non-deterministic)
+        # input order, making first/last/consecutive picks vary across runs.
+        self._boundaries = sorted(
+            boundaries, key=lambda x: message_sort_key(x.first_message())
+        )
 
     def get_first_message_inside_range(self, date_range: tuple = None) -> dict:
         """Returns the first message across all boundaries that falls within date_range.
@@ -39,7 +46,10 @@ class Boundaries:
             for m in [b.start] + b.end + [b.first_message_in_range]
             if m["timestamp"] >= start_ds
         )
-        return min(candidates, key=lambda m: m["timestamp"], default=None)
+        # min over (timestamp, msgid): with timestamp alone, tied candidates
+        # resolve to encounter order (non-deterministic across runs), and the
+        # pick becomes a closed gap's ON message -- end_* fields would drift.
+        return min(candidates, key=message_sort_key, default=None)
 
     def consecutive_boundaries(self):
         return list(zip(self._boundaries[:-1], self._boundaries[1:]))

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -17,9 +17,8 @@ logger = logging.getLogger(__name__)
 class Boundaries:
     """Container for Boundary objects."""
     def __init__(self, boundaries: list[Boundary]) -> None:
-        self._boundaries = sorted(
-            boundaries, key=lambda x: timestamp_msgid_key(x.first_message())
-        )
+        _key = timestamp_msgid_key()
+        self._boundaries = sorted(boundaries, key=lambda x: _key(x.first_message()))
 
     def get_first_message_inside_range(self, date_range: tuple = None) -> dict:
         """Returns the first message across all boundaries that falls within date_range.
@@ -42,7 +41,7 @@ class Boundaries:
             for m in [b.start] + b.end + [b.first_message_in_range]
             if m["timestamp"] >= start_ds
         )
-        return min(candidates, key=timestamp_msgid_key, default=None)
+        return min(candidates, key=timestamp_msgid_key(), default=None)
 
     def consecutive_boundaries(self):
         return list(zip(self._boundaries[:-1], self._boundaries[1:]))
@@ -151,7 +150,7 @@ class ProcessBoundaries(DoFn):
             last_boundary = boundaries.last_boundary()
             last_message = last_boundary.last_message()
 
-            last_message_dt = datetime_from_timestamp(last_message["timestamp"])
+            last_message_dt = datetime_from_timestamp(last_message[self.KEY_TIMESTAMP])
 
             comparison_date = last_message_dt.date()
             if self._date_range is not None:

--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -8,7 +8,7 @@ from gfw.common.datetime import datetime_from_timestamp, datetime_from_date
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
 from pipe_gaps.common.beam.side_inputs import SideInputs
-from pipe_gaps.common.sorting import message_sort_key
+from pipe_gaps.common.sorting import timestamp_msgid_key
 from pipe_gaps.pipelines.detect.fns.extract_group_boundary import Boundary
 
 logger = logging.getLogger(__name__)
@@ -17,12 +17,8 @@ logger = logging.getLogger(__name__)
 class Boundaries:
     """Container for Boundary objects."""
     def __init__(self, boundaries: list[Boundary]) -> None:
-        # (timestamp, msgid) total order on the first message: boundaries
-        # whose first messages tie on timestamp (e.g. different seg_ids of
-        # the same vessel) would otherwise keep their (non-deterministic)
-        # input order, making first/last/consecutive picks vary across runs.
         self._boundaries = sorted(
-            boundaries, key=lambda x: message_sort_key(x.first_message())
+            boundaries, key=lambda x: timestamp_msgid_key(x.first_message())
         )
 
     def get_first_message_inside_range(self, date_range: tuple = None) -> dict:
@@ -46,10 +42,7 @@ class Boundaries:
             for m in [b.start] + b.end + [b.first_message_in_range]
             if m["timestamp"] >= start_ds
         )
-        # min over (timestamp, msgid): with timestamp alone, tied candidates
-        # resolve to encounter order (non-deterministic across runs), and the
-        # pick becomes a closed gap's ON message -- end_* fields would drift.
-        return min(candidates, key=message_sort_key, default=None)
+        return min(candidates, key=timestamp_msgid_key, default=None)
 
     def consecutive_boundaries(self):
         return list(zip(self._boundaries[:-1], self._boundaries[1:]))

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -11,6 +11,7 @@ from gfw.common.iterables import binary_search_first_ge
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
 from pipe_gaps.common.beam.side_inputs import SideInputs
+from pipe_gaps.common.sorting import message_sort_key
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,8 @@ class ProcessGroup(DoFn):
         key, messages = group
 
         messages = list(messages)  # On dataflow, this is a _ConcatSequence object.
-        messages.sort(key=lambda x: x[self.KEY_TIMESTAMP])
+        # (timestamp, msgid) total order -- see pipe_gaps.common.sorting.
+        messages.sort(key=lambda x: message_sort_key(x, self.KEY_TIMESTAMP))
 
         window_start_time = window.start.to_utc_datetime(has_tz=True)
         window_end_time = window.end.to_utc_datetime(has_tz=True)

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -42,7 +42,7 @@ class ProcessGroup(DoFn):
         key, messages = group
 
         messages = list(messages)  # On dataflow, this is a _ConcatSequence object.
-        messages.sort(key=lambda x: timestamp_msgid_key(x, self.KEY_TIMESTAMP))
+        messages.sort(key=timestamp_msgid_key(self.KEY_TIMESTAMP))
 
         window_start_time = window.start.to_utc_datetime(has_tz=True)
         window_end_time = window.end.to_utc_datetime(has_tz=True)

--- a/src/pipe_gaps/pipelines/detect/fns/process_group.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_group.py
@@ -11,7 +11,7 @@ from gfw.common.iterables import binary_search_first_ge
 from pipe_gaps.core import GapDetector
 from pipe_gaps.common.key import Key
 from pipe_gaps.common.beam.side_inputs import SideInputs
-from pipe_gaps.common.sorting import message_sort_key
+from pipe_gaps.common.sorting import timestamp_msgid_key
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,7 @@ class ProcessGroup(DoFn):
         key, messages = group
 
         messages = list(messages)  # On dataflow, this is a _ConcatSequence object.
-        # (timestamp, msgid) total order -- see pipe_gaps.common.sorting.
-        messages.sort(key=lambda x: message_sort_key(x, self.KEY_TIMESTAMP))
+        messages.sort(key=lambda x: timestamp_msgid_key(x, self.KEY_TIMESTAMP))
 
         window_start_time = window.start.to_utc_datetime(has_tz=True)
         window_end_time = window.end.to_utc_datetime(has_tz=True)

--- a/src/pipe_gaps/pipelines/detect/messages.py
+++ b/src/pipe_gaps/pipelines/detect/messages.py
@@ -27,7 +27,7 @@ class Messages:
         Sorting is done in-place to avoid creating a new list — messages can be large.
         Result is cached so subsequent calls do not re-sort.
         """
-        self._messages.sort(key=lambda m: timestamp_msgid_key(m, self._timestamp_key))
+        self._messages.sort(key=timestamp_msgid_key(self._timestamp_key))
         return self._messages
 
     def first_message_at_or_after(self, timestamp: float) -> dict:

--- a/src/pipe_gaps/pipelines/detect/messages.py
+++ b/src/pipe_gaps/pipelines/detect/messages.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 from gfw.common.iterables import binary_search_first_ge
 
-from pipe_gaps.common.sorting import message_sort_key
+from pipe_gaps.common.sorting import timestamp_msgid_key
 
 
 class Messages:
@@ -24,14 +24,10 @@ class Messages:
     def sorted(self) -> list[dict]:
         """Returns messages sorted by ``(timestamp, msgid)``.
 
-        The msgid tiebreaker makes the order a total one: messages with tied
-        timestamps would otherwise keep their (non-deterministic) input
-        order, making first/last picks vary across runs on identical data.
-
         Sorting is done in-place to avoid creating a new list — messages can be large.
         Result is cached so subsequent calls do not re-sort.
         """
-        self._messages.sort(key=lambda m: message_sort_key(m, self._timestamp_key))
+        self._messages.sort(key=lambda m: timestamp_msgid_key(m, self._timestamp_key))
         return self._messages
 
     def first_message_at_or_after(self, timestamp: float) -> dict:

--- a/src/pipe_gaps/pipelines/detect/messages.py
+++ b/src/pipe_gaps/pipelines/detect/messages.py
@@ -2,6 +2,8 @@ from functools import cached_property
 
 from gfw.common.iterables import binary_search_first_ge
 
+from pipe_gaps.common.sorting import message_sort_key
+
 
 class Messages:
     """Sorted collection of position messages with time-based retrieval methods.
@@ -20,12 +22,16 @@ class Messages:
 
     @cached_property
     def sorted(self) -> list[dict]:
-        """Returns messages sorted by timestamp.
+        """Returns messages sorted by ``(timestamp, msgid)``.
+
+        The msgid tiebreaker makes the order a total one: messages with tied
+        timestamps would otherwise keep their (non-deterministic) input
+        order, making first/last picks vary across runs on identical data.
 
         Sorting is done in-place to avoid creating a new list — messages can be large.
         Result is cached so subsequent calls do not re-sort.
         """
-        self._messages.sort(key=lambda m: m[self._timestamp_key])
+        self._messages.sort(key=lambda m: message_sort_key(m, self._timestamp_key))
         return self._messages
 
     def first_message_at_or_after(self, timestamp: float) -> dict:

--- a/tests/core/test_gap_detector.py
+++ b/tests/core/test_gap_detector.py
@@ -291,3 +291,33 @@ def test_gap_implied_speed_knots_handles_exceptions():
     # Case 2: gap_duration_h is zero (ZeroDivisionError)
     result_zero_duration = detector._gap_implied_speed_knots(1000.0, 0.0)
     assert result_zero_duration is None
+
+
+def test_detect_is_order_independent_on_timestamp_ties():
+    """Messages tied on timestamp must sort deterministically ((timestamp,
+    msgid) total order); otherwise which message becomes a gap's OFF/ON --
+    and hence gap_id and all end_* fields -- depends on the input order,
+    which is non-deterministic for messages read from BigQuery."""
+    base = datetime(2024, 1, 1, 0, tzinfo=timezone.utc).timestamp()
+
+    def msg(ts, msgid, lat):
+        return {
+            "ssvid": "12345",
+            "msgid": msgid,
+            "timestamp": ts,
+            "lat": lat,
+            "lon": -122.0,
+            "receiver_type": "terrestrial",
+        }
+
+    earlier = msg(base, "m0", 37.0)
+    # Two messages tied on the OFF-candidate timestamp, then a long gap.
+    tied_a = msg(base + 3600, "a", 38.0)
+    tied_b = msg(base + 3600, "b", 39.0)
+    later = msg(base + 3600 + 13 * 3600, "m3", 40.0)  # 13h > default threshold
+
+    detector = GapDetector()
+    gaps_forward = detector.detect([earlier, tied_a, tied_b, later])
+    gaps_reverse = detector.detect([earlier, tied_b, tied_a, later])
+
+    assert gaps_forward == gaps_reverse

--- a/tests/core/test_gap_detector.py
+++ b/tests/core/test_gap_detector.py
@@ -10,6 +10,7 @@ def example_messages():
     return [
         {
             "ssvid": "12345",
+            "msgid": "msg-0",
             "timestamp": base_time,
             "lat": 37.7749,
             "lon": -122.4194,
@@ -17,6 +18,7 @@ def example_messages():
         },
         {
             "ssvid": "12345",
+            "msgid": "msg-1",
             "timestamp": base_time + 3600,  # 1 hour later
             "lat": 37.7750,
             "lon": -122.4195,
@@ -24,6 +26,7 @@ def example_messages():
         },
         {
             "ssvid": "12345",
+            "msgid": "msg-2",
             "timestamp": base_time + 7200,  # 2 hours later
             "lat": 37.7751,
             "lon": -122.4196,
@@ -31,6 +34,7 @@ def example_messages():
         },
         {
             "ssvid": "12345",
+            "msgid": "msg-3",
             "timestamp": base_time + 43200,  # 12 hours later
             "lat": 37.7800,
             "lon": -122.4200,
@@ -223,10 +227,11 @@ def test_normalize_off_on_messages(example_messages):
 # Optional: test internal sort method actually sorts
 def test_sort_messages_sorts_unsorted():
     detector = GapDetector()
+    TER = "terrestrial"
     messages = [
-        {"timestamp": 3, "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": "terrestrial"},
-        {"timestamp": 1, "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": "terrestrial"},
-        {"timestamp": 2, "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": "terrestrial"},
+        {"timestamp": 3, "msgid": "c", "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": TER},
+        {"timestamp": 1, "msgid": "a", "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": TER},
+        {"timestamp": 2, "msgid": "b", "ssvid": "a", "lat": 0, "lon": 0, "receiver_type": TER},
     ]
     detector._sort_messages(messages)
     timestamps = [m["timestamp"] for m in messages]

--- a/tests/pipelines/detect/fns/test_process_boundaries.py
+++ b/tests/pipelines/detect/fns/test_process_boundaries.py
@@ -1,0 +1,133 @@
+import copy
+from datetime import date, timedelta
+
+from pipe_gaps.core import GapDetector
+from pipe_gaps.common.key import Key
+from pipe_gaps.pipelines.detect.fns.extract_group_boundary import Boundary
+from pipe_gaps.pipelines.detect.fns.process_boundaries import (
+    Boundaries,
+    ProcessBoundaries,
+)
+
+from tests.conftest import create_message, utc_datetime
+
+
+SSVID = "446013750"
+
+
+def _ssvid_message(time, seg_id, msgid, lat=10.0, lon=20.0):
+    return create_message(
+        time=time,
+        ssvid=SSVID,
+        seg_id=seg_id,
+        msgid=msgid,
+        lat=lat,
+        lon=lon,
+    )
+
+
+def test_boundaries_ordering_is_deterministic_when_first_message_timestamps_tie():
+    ts = utc_datetime(2024, 1, 1, 12, 0, 0)
+    later = ts + timedelta(hours=2)
+
+    boundary_a = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(ts, seg_id="seg_a", msgid="a_start"),
+        end=[_ssvid_message(later, seg_id="seg_a", msgid="a_end")],
+    )
+    boundary_b = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(ts, seg_id="seg_b", msgid="b_start"),
+        end=[_ssvid_message(later, seg_id="seg_b", msgid="b_end")],
+    )
+
+    forward = Boundaries([boundary_a, boundary_b])
+    reverse = Boundaries([boundary_b, boundary_a])
+
+    assert forward.first_boundary() == reverse.first_boundary()
+    assert forward.last_boundary() == reverse.last_boundary()
+    assert forward.consecutive_boundaries() == reverse.consecutive_boundaries()
+
+
+def test_get_first_message_inside_range_is_deterministic_on_timestamp_ties():
+    range_start_date = date(2024, 1, 2)
+    range_end_date = date(2024, 1, 3)
+    ts_at_range = utc_datetime(2024, 1, 2, 0, 0, 0)
+    earlier = utc_datetime(2024, 1, 1, 23, 0, 0)
+
+    m_a = _ssvid_message(ts_at_range, seg_id="seg_a", msgid="a", lat=1.0)
+    m_b = _ssvid_message(ts_at_range, seg_id="seg_b", msgid="b", lat=2.0)
+
+    boundary_a = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(earlier, seg_id="seg_a", msgid="a_pre"),
+        end=[_ssvid_message(earlier, seg_id="seg_a", msgid="a_pre")],
+        first_message_in_range=m_a,
+    )
+    boundary_b = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(earlier, seg_id="seg_b", msgid="b_pre"),
+        end=[_ssvid_message(earlier, seg_id="seg_b", msgid="b_pre")],
+        first_message_in_range=m_b,
+    )
+
+    forward = Boundaries([boundary_a, boundary_b])
+    reverse = Boundaries([boundary_b, boundary_a])
+
+    pick_forward = forward.get_first_message_inside_range((range_start_date, range_end_date))
+    pick_reverse = reverse.get_first_message_inside_range((range_start_date, range_end_date))
+
+    assert pick_forward == pick_reverse
+
+
+def test_process_boundaries_closes_open_gap_with_same_on_regardless_of_input_order():
+    """End-to-end determinism check at the boundary-recovery seam.
+
+    Constructs an open gap (in side inputs) plus two candidate ON messages tied
+    on timestamp at the range start. ProcessBoundaries.process must pick the
+    same ON message -- and thus emit byte-identical closed gaps -- regardless
+    of the order boundaries arrive in.
+    """
+    range_start_date = date(2024, 1, 2)
+    range_end_date = date(2024, 1, 3)
+    ts_at_range = utc_datetime(2024, 1, 2, 0, 0, 0)
+    off_ts = utc_datetime(2023, 12, 25, 0, 0, 0)
+    pre_range = utc_datetime(2024, 1, 1, 22, 0, 0)
+
+    gap_detector = GapDetector(threshold=12, normalize_output=True)
+    key = Key(["ssvid"])
+
+    off_m = _ssvid_message(off_ts, seg_id="seg_off", msgid="off")
+    open_gap = gap_detector.create_gap(off_m=off_m, previous_positions=[])
+
+    m_a = _ssvid_message(ts_at_range, seg_id="seg_a", msgid="a", lat=1.0)
+    m_b = _ssvid_message(ts_at_range, seg_id="seg_b", msgid="b", lat=2.0)
+
+    boundary_a = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(pre_range, seg_id="seg_a", msgid="a_pre"),
+        end=[_ssvid_message(pre_range, seg_id="seg_a", msgid="a_pre")],
+        first_message_in_range=m_a,
+    )
+    boundary_b = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(pre_range, seg_id="seg_b", msgid="b_pre"),
+        end=[_ssvid_message(pre_range, seg_id="seg_b", msgid="b_pre")],
+        first_message_in_range=m_b,
+    )
+
+    dofn = ProcessBoundaries(
+        gap_detector=gap_detector,
+        key=key,
+        eval_last=False,
+        date_range=(range_start_date, range_end_date),
+    )
+
+    def _run(boundaries):
+        # GapDetector.create_gap mutates its `base_gap` in place when closing
+        # an open gap. The open gap from side inputs and every emitted gap dict
+        # are therefore deep-copied here so the two runs cannot share state.
+        si = {SSVID: [copy.deepcopy(open_gap)]}
+        return [copy.deepcopy(g) for g in dofn.process((SSVID, boundaries), side_inputs=si)]
+
+    assert _run([boundary_a, boundary_b]) == _run([boundary_b, boundary_a])

--- a/tests/pipelines/detect/test_messages.py
+++ b/tests/pipelines/detect/test_messages.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from pipe_gaps.pipelines.detect.messages import Messages
+
+from tests.conftest import create_message, utc_datetime
+
+
+def test_first_message_at_or_after_is_order_independent_on_timestamp_ties():
+    ts = utc_datetime(2024, 1, 1, 12, 0, 0)
+    earlier = create_message(time=ts - timedelta(hours=1), seg_id="seg_a", msgid="earlier")
+    m_a = create_message(time=ts, seg_id="seg_a", msgid="a", lat=10.0, lon=20.0)
+    m_b = create_message(time=ts, seg_id="seg_b", msgid="b", lat=30.0, lon=40.0)
+
+    forward = Messages([earlier, m_a, m_b])
+    reverse = Messages([earlier, m_b, m_a])
+
+    pick_forward = forward.first_message_at_or_after(ts.timestamp())
+    pick_reverse = reverse.first_message_at_or_after(ts.timestamp())
+
+    assert pick_forward == pick_reverse


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-4050

---

@tomaslink this addresses non-deterministic gaps due to timestamp-duplicated messages which currently result in arbitrarily chosen ON- and OFF-messages.

I've already run data integration tests and the fix passes them ([cloud build](https://console.cloud.google.com/cloud-build/builds/7d03ed13-c149-4be6-9bd7-ea21911e3e12?project=world-fishing-827)).

The current main branch on the other hand fails due to non-determinism ([cloud build](https://console.cloud.google.com/cloud-build/builds/526ac74a-7d88-473d-8bac-7f1f7fb41380?project=world-fishing-827)).

The build logs contain references to tables that were generated if you want to debug e.g. why main fails.