### PR TITLE
first_message_at_or_after returning message outside of window if no message was in window.

### DIFF
--- a/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
+++ b/src/pipe_gaps/pipelines/detect/fns/process_boundaries.py
@@ -18,9 +18,10 @@ class Boundaries:
     """Container for Boundary objects."""
     def __init__(self, boundaries: list[Boundary]) -> None:
         _key = timestamp_msgid_key()
-        self._boundaries = sorted(boundaries, key=lambda x: _key(x.first_message()))
+        self._boundaries = filter(lambda boundary: boundary.start is not None, boundaries)
+        self._boundaries = sorted(self._boundaries, key=lambda x: _key(x.first_message()))
 
-    def get_first_message_inside_range(self, date_range: tuple = None) -> dict:
+    def get_first_message_inside_range(self, date_range: tuple = None) -> dict | None:
         """Returns the first message across all boundaries that falls within date_range.
 
         Searches start, end and first_message_in_range of each boundary and returns
@@ -32,6 +33,10 @@ class Boundaries:
         """
         if date_range is None:
             # TODO: should we make date_range mandatory for the pipeline?
+
+            return None
+
+        if len(self._boundaries) == 0:
             return None
 
         start_ds = datetime_from_date(date_range[0]).timestamp()
@@ -39,7 +44,7 @@ class Boundaries:
             m
             for b in self._boundaries
             for m in [b.start] + b.end + [b.first_message_in_range]
-            if m["timestamp"] >= start_ds
+            if m is not None and m["timestamp"] >= start_ds
         )
         return min(candidates, key=timestamp_msgid_key(), default=None)
 

--- a/src/pipe_gaps/pipelines/detect/messages.py
+++ b/src/pipe_gaps/pipelines/detect/messages.py
@@ -30,16 +30,20 @@ class Messages:
         self._messages.sort(key=timestamp_msgid_key(self._timestamp_key))
         return self._messages
 
-    def first_message_at_or_after(self, timestamp: float) -> dict:
-        """Returns first message at or after the given timestamp.
+    def first_message_at_or_after(self, timestamp: float) -> dict | None:
+        """Returns first message at or after the given timestamp, or ``None`` if no messages were found at or after the given timestamp.
 
         Args:
             timestamp:
                 Unix timestamp to search from.
+        Returns:
+            The first message at or after the given ``timestamp``
+             or ``None`` if no such message exists.
         """
         idx = binary_search_first_ge(self.sorted, timestamp, key=lambda m: m[self._timestamp_key])
 
-        return self.sorted[max(idx, 0)]
+        # Covers binary search returning below 0 and also avoids index error on empty list.
+        return self.sorted[idx] if 0 <= idx < len(self.sorted) else None
 
     def last_messages(self, offset: int = 0) -> list[dict]:
         """Returns all messages within offset seconds before the last message.

--- a/tests/pipelines/detect/fns/test_extract_group_boundary.py
+++ b/tests/pipelines/detect/fns/test_extract_group_boundary.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+from collections import namedtuple
+from datetime import date
+
+from pipe_gaps.pipelines.detect.fns.extract_group_boundary import ExtractGroupBoundary
+
+from tests.conftest import create_message, utc_datetime
+
+
+SSVID = "446013750"
+WINDOW_OFFSET_S = 12 * 3600  # 12 hours, matching the pipeline default (n_hours_before).
+
+_Key = namedtuple("_Key", ["ssvid"])
+
+
+class _FakeWindow:
+    """Minimal stand-in for a Beam ``IntervalWindow``.
+
+    ``ExtractGroupBoundary.process`` only ever reads ``window.start.seconds()``,
+    so we expose exactly that. This avoids depending on the Beam ``Timestamp``
+    constructor API and keeps the test runnable without a Beam runner, exactly
+    like ``test_process_boundaries.py`` calls ``dofn.process(...)`` directly.
+    """
+
+    def __init__(self, start_s: float) -> None:
+        self.start = SimpleNamespace(seconds=lambda: start_s)
+
+
+def _extract(messages, window_start_s, offset_s=WINDOW_OFFSET_S, date_range=None):
+    dofn = ExtractGroupBoundary(window_offset_s=offset_s, date_range=date_range)
+    window = _FakeWindow(window_start_s)
+    return list(dofn.process((_Key(SSVID), messages), window=window))
+
+
+def test_extract_group_boundary_start_picks_first_message_in_window_body():
+    """Positive path: ``start`` is the first message at/after window_start + offset.
+
+    A message in the overlap (lookback) region before the offset must be ignored
+    in favour of the first message in the window body. Guards against a fix that
+    over-corrects and breaks the normal selection.
+    """
+    window_start = utc_datetime(2024, 1, 1, 0, 0, 0)
+    start_time = window_start.timestamp() + WINDOW_OFFSET_S  # noon
+
+    overlap = create_message(time=utc_datetime(2024, 1, 1, 6), ssvid=SSVID, msgid="overlap")
+    first_in_body = create_message(time=utc_datetime(2024, 1, 1, 13), ssvid=SSVID, msgid="body_1")
+    later = create_message(time=utc_datetime(2024, 1, 1, 20), ssvid=SSVID, msgid="body_2")
+
+    boundaries = _extract([overlap, first_in_body, later], window_start_s=window_start.timestamp())
+
+    assert len(boundaries) == 1
+    assert boundaries[0].start == first_in_body
+    assert boundaries[0].start["timestamp"] >= start_time
+
+
+def test_extract_group_boundary_start_is_at_or_after_window_start_plus_offset():
+    """The bug, at the seam where it bites.
+
+    When a window contains messages only in its overlap (lookback) region, there
+    is no message at or after ``window.start + offset``. ``first_message_at_or_after``
+    then hits its ``self.sorted[max(idx, 0)]`` clamp and returns the EARLIEST
+    message -- which predates the boundary -- so ``Boundary.start`` is silently
+    wrong. That ``start`` is later used as ``right.start`` in
+    ``ProcessBoundaries.consecutive_boundaries()`` (``left.end + [right.start]``),
+    perturbing cross-window gap detection.
+
+    This test is agnostic about HOW the no-match case is fixed: not emitting a
+    boundary, or setting ``start`` to None, both satisfy the contract below.
+    Today it fails because the clamp emits ``start`` = the 02:00 message.
+    """
+    window_start = utc_datetime(2024, 1, 1, 0, 0, 0)
+    start_time = window_start.timestamp() + WINDOW_OFFSET_S  # noon
+
+    # Every message lands strictly before start_time (i.e. in the overlap region).
+    messages = [
+        create_message(time=utc_datetime(2024, 1, 1, 2), ssvid=SSVID, msgid="m02"),
+        create_message(time=utc_datetime(2024, 1, 1, 6), ssvid=SSVID, msgid="m06"),
+        create_message(time=utc_datetime(2024, 1, 1, 10), ssvid=SSVID, msgid="m10"),
+    ]
+
+    boundaries = _extract(messages, window_start_s=window_start.timestamp())
+
+    # Contract: any emitted boundary's start must be genuinely at/after the
+    # boundary time -- never a message that predates window_start + offset.
+    for b in boundaries:
+        assert b.start is None or b.start["timestamp"] >= start_time
+
+
+# --- date_range path: first_message_in_range (currently untested branch) ---
+#
+# When date_range is provided, ExtractGroupBoundary also calls
+# first_message_at_or_after(range_start) to populate first_message_in_range.
+# No existing test exercises this branch at all (_extract defaults date_range
+# to None), so the no-match case carries the same clamp bug as `start`.
+
+
+def test_extract_group_boundary_first_message_in_range_is_at_or_after_range_start():
+    """The bug on the date_range branch.
+
+    When every message predates date_range[0], there is no message "at or after"
+    the range start, so first_message_at_or_after hits its ``self.sorted[max(idx, 0)]``
+    clamp and returns the EARLIEST message -- which predates the range. That value
+    is stored as ``Boundary.first_message_in_range`` and later trusted by
+    ProcessBoundaries as the ON message when closing an open gap
+    (``get_first_message_inside_range`` -> ``_close_open_gap``), so a pre-range
+    value silently corrupts gap recovery.
+
+    Contract: ``first_message_in_range`` is either None (no qualifying message)
+    or a message at/after the range start. Today it fails: the clamp stores the
+    02:00 message, which predates the 2024-01-02 range start.
+    """
+    range_start = date(2024, 1, 2)
+    range_end = date(2024, 1, 3)
+
+    # Window opens the day before the range; every message lands before range start.
+    window_start = utc_datetime(2024, 1, 1, 0, 0, 0)
+    messages = [
+        create_message(time=utc_datetime(2024, 1, 1, 2), ssvid=SSVID, msgid="m02"),
+        create_message(time=utc_datetime(2024, 1, 1, 20), ssvid=SSVID, msgid="m20"),
+    ]
+
+    boundaries = _extract(
+        messages,
+        window_start_s=window_start.timestamp(),
+        date_range=(range_start, range_end),
+    )
+
+    range_start_ts = utc_datetime(2024, 1, 2, 0, 0, 0).timestamp()
+    for b in boundaries:
+        fmir = b.first_message_in_range
+        assert fmir is None or fmir["timestamp"] >= range_start_ts

--- a/tests/pipelines/detect/fns/test_process_boundaries.py
+++ b/tests/pipelines/detect/fns/test_process_boundaries.py
@@ -131,3 +131,95 @@ def test_process_boundaries_closes_open_gap_with_same_on_regardless_of_input_ord
         return [copy.deepcopy(g) for g in dofn.process((SSVID, boundaries), side_inputs=si)]
 
     assert _run([boundary_a, boundary_b]) == _run([boundary_b, boundary_a])
+
+
+# --- None propagation from first_message_at_or_after (the fix thread) ---
+#
+# Once first_message_at_or_after returns None for the no-match case,
+# ExtractGroupBoundary can emit a Boundary whose `start` and/or
+# `first_message_in_range` is None. These tests feed those None-bearing
+# boundaries into Boundaries/ProcessBoundaries to pin exactly where None breaks
+# the consumer. No existing test ever constructs a boundary with a None field.
+
+
+def test_process_boundaries_handles_boundary_with_none_start():
+    """A window with no message at/after window_start+offset yields start=None.
+
+    ``Boundaries.__init__`` sorts by ``first_message()`` (== ``start``) using
+    ``timestamp_msgid_key``, and ``consecutive_boundaries()`` builds
+    ``left.end + [right.start]`` which is handed to the gap detector. A None
+    ``start`` therefore flows straight into the sort key and the detector input.
+
+    Contract: ProcessBoundaries must handle a missing in-window start without
+    crashing. Today this raises in ``Boundaries.__init__`` (timestamp lookup on
+    None) before any gap logic runs.
+    """
+    ts = utc_datetime(2024, 1, 1, 12, 0, 0)
+
+    none_start = Boundary(
+        ssvid=SSVID,
+        start=None,
+        end=[_ssvid_message(ts, seg_id="seg_a", msgid="a_end")],
+    )
+    normal = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(ts + timedelta(hours=2), seg_id="seg_b", msgid="b_start"),
+        end=[_ssvid_message(ts + timedelta(hours=4), seg_id="seg_b", msgid="b_end")],
+    )
+
+    dofn = ProcessBoundaries(
+        gap_detector=GapDetector(threshold=12, normalize_output=True),
+        key=Key(["ssvid"]),
+        eval_last=False,
+    )
+
+    # Should not raise: a missing in-window start must be handled, not crash.
+    list(dofn.process((SSVID, [none_start, normal])))
+
+
+def test_get_first_message_inside_range_handles_none_first_message_in_range():
+    """A lookback window before the range carries first_message_in_range=None.
+
+    first_message_in_range = first_message_at_or_after(range_start), so it is None
+    for any window whose messages all predate range_start -- i.e. the before-range
+    lookback windows, which are retained on purpose (FilterWindowsByDateRange only
+    trims windows starting after the range) and collected globally per ssvid. Such
+    a boundary has a perfectly valid `start` (a pre-range message) but a None
+    first_message_in_range. This is a realizable production state, not contrived:
+    a valid in-range `start` with None first_message_in_range is impossible, but a
+    pre-range `start` with None first_message_in_range is exactly a lookback window.
+
+    ``get_first_message_inside_range`` builds
+    ``[b.start] + b.end + [b.first_message_in_range]`` and evaluates
+    ``m["timestamp"]`` on every element, so the None raises ``TypeError`` before
+    the filter can skip it. Today this path crashes once first_message_at_or_after
+    starts returning None; every existing test supplies a real message here.
+
+    Contract: skip the None element and still return the earliest in-range
+    message -- here, the in-range boundary's message, never crash.
+    """
+    range_start_date = date(2024, 1, 2)
+    range_end_date = date(2024, 1, 3)
+    pre_range = utc_datetime(2024, 1, 1, 22, 0, 0)   # before range_start
+    in_range = utc_datetime(2024, 1, 2, 6, 0, 0)     # at/after range_start
+
+    lookback = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(pre_range, seg_id="seg_a", msgid="a_start"),
+        end=[_ssvid_message(pre_range, seg_id="seg_a", msgid="a_end")],
+        # All messages predate range_start -> first_message_in_range is None.
+    )
+    in_range_boundary = Boundary(
+        ssvid=SSVID,
+        start=_ssvid_message(in_range, seg_id="seg_b", msgid="b_start"),
+        end=[_ssvid_message(in_range, seg_id="seg_b", msgid="b_end")],
+        first_message_in_range=_ssvid_message(in_range, seg_id="seg_b", msgid="b_start"),
+    )
+
+    boundaries = Boundaries([lookback, in_range_boundary])
+
+    result = boundaries.get_first_message_inside_range((range_start_date, range_end_date))
+
+    range_start_ts = utc_datetime(2024, 1, 2, 0, 0, 0).timestamp()
+    assert result is not None
+    assert result["timestamp"] >= range_start_ts

--- a/tests/pipelines/detect/test_messages.py
+++ b/tests/pipelines/detect/test_messages.py
@@ -18,3 +18,89 @@ def test_first_message_at_or_after_is_order_independent_on_timestamp_ties():
     pick_reverse = reverse.first_message_at_or_after(ts.timestamp())
 
     assert pick_forward == pick_reverse
+
+
+# --- first_message_at_or_after: positive paths (lock in correct behavior) ---
+
+
+def test_first_message_at_or_after_returns_exact_match():
+    ts = utc_datetime(2024, 1, 1, 12)
+    before = create_message(time=ts - timedelta(hours=2), msgid="before")
+    on_ts = create_message(time=ts, msgid="on_ts")
+    after = create_message(time=ts + timedelta(hours=2), msgid="after")
+
+    msgs = Messages([before, on_ts, after])
+
+    assert msgs.first_message_at_or_after(ts.timestamp()) == on_ts
+
+
+def test_first_message_at_or_after_returns_next_when_between_messages():
+    before = create_message(time=utc_datetime(2024, 1, 1, 10), msgid="before")
+    after = create_message(time=utc_datetime(2024, 1, 1, 14), msgid="after")
+
+    msgs = Messages([before, after])
+
+    # A timestamp strictly between the two messages must return the later one.
+    requested = utc_datetime(2024, 1, 1, 12).timestamp()
+    assert msgs.first_message_at_or_after(requested) == after
+
+
+def test_first_message_at_or_after_returns_earliest_when_before_all_messages():
+    earliest = create_message(time=utc_datetime(2024, 1, 1, 10), msgid="earliest")
+    latest = create_message(time=utc_datetime(2024, 1, 1, 20), msgid="latest")
+
+    msgs = Messages([earliest, latest])
+
+    # Requested time precedes every message, so the earliest message is itself
+    # "at or after" it -- returning it is correct (timestamp >= requested holds).
+    requested = utc_datetime(2024, 1, 1, 0).timestamp()
+    result = msgs.first_message_at_or_after(requested)
+
+    assert result == earliest
+    assert result["timestamp"] >= requested
+
+
+# --- first_message_at_or_after: the bug (no message qualifies) ---
+#
+# When EVERY message predates the requested timestamp, there is no "first
+# message at or after" it. The current implementation does:
+#
+#     idx = binary_search_first_ge(...)        # -> -1 (nothing >= timestamp)
+#     return self.sorted[max(idx, 0)]          # -> sorted[0], the EARLIEST msg
+#
+# i.e. it silently returns the earliest message, whose timestamp is strictly
+# BEFORE the requested time -- violating the method's "at or after" contract.
+#
+# The tests below fail today and should pass once the no-match case is handled.
+# They are intentionally agnostic about HOW it is signalled: if the fix returns
+# a sentinel other than None (or raises), adjust the expectation to match.
+
+
+def test_first_message_at_or_after_does_not_return_earlier_message_when_none_qualify():
+    earliest = create_message(time=utc_datetime(2024, 1, 1, 10), msgid="earliest")
+    latest = create_message(time=utc_datetime(2024, 1, 1, 12), msgid="latest")
+
+    msgs = Messages([earliest, latest])
+
+    # Strictly after every message in the collection.
+    requested = utc_datetime(2024, 1, 2, 0).timestamp()
+    result = msgs.first_message_at_or_after(requested)
+
+    # Contract: either there is no qualifying message (None), or the one
+    # returned is genuinely at or after the requested timestamp. It must never
+    # be a message that predates `requested`.
+    assert result is None or result["timestamp"] >= requested
+
+
+def test_first_message_at_or_after_when_none_qualify_does_not_silently_pick_sorted_zero():
+    earliest = create_message(time=utc_datetime(2024, 1, 1, 10), msgid="earliest")
+    latest = create_message(time=utc_datetime(2024, 1, 1, 12), msgid="latest")
+
+    msgs = Messages([earliest, latest])
+
+    requested = utc_datetime(2024, 1, 5, 0).timestamp()
+    result = msgs.first_message_at_or_after(requested)
+
+    # Today the bug surfaces as returning `earliest` (sorted[0]). Pinning this
+    # symptom directly makes the regression obvious if max(idx, 0) comes back.
+    assert result is not earliest


### PR DESCRIPTION
Now first_message_at_or_after  will return None if there are no messages inside the given window. Now the resulting boundaries are dropped during processing as they are essentially empty.

Let me know if you'd like something tweaked on this.

Tests written by claude for TDD, fixes in code written by me.